### PR TITLE
Feature: Add YAML config file support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "pandas>=2.0",
     "scikit-learn>=1.3",
     "httpx>=0.25",
+    "pyyaml>=6.0",
 ]
 
 [project.optional-dependencies]

--- a/src/pvforecast/config.py
+++ b/src/pvforecast/config.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
+
+import yaml
+
+logger = logging.getLogger(__name__)
 
 
 def _default_db_path() -> Path:
@@ -12,6 +17,10 @@ def _default_db_path() -> Path:
 
 def _default_model_path() -> Path:
     return Path.home() / ".local" / "share" / "pvforecast" / "model.pkl"
+
+
+def _default_config_path() -> Path:
+    return Path.home() / ".config" / "pvforecast" / "config.yaml"
 
 
 @dataclass
@@ -38,6 +47,105 @@ class Config:
         """Erstellt notwendige Verzeichnisse."""
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self.model_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def to_dict(self) -> dict:
+        """Konvertiert Config zu Dictionary."""
+        return {
+            "location": {
+                "latitude": self.latitude,
+                "longitude": self.longitude,
+                "timezone": self.timezone,
+            },
+            "system": {
+                "peak_kwp": self.peak_kwp,
+                "name": self.system_name,
+            },
+            "data": {
+                "db_path": str(self.db_path),
+                "model_path": str(self.model_path),
+            },
+            "api": {
+                "weather_provider": self.weather_provider,
+            },
+        }
+
+    def save(self, path: Path | None = None) -> None:
+        """Speichert Config als YAML-Datei."""
+        if path is None:
+            path = _default_config_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as f:
+            yaml.dump(self.to_dict(), f, default_flow_style=False, allow_unicode=True)
+        logger.info(f"Config gespeichert: {path}")
+
+
+def load_config(path: Path | None = None) -> Config:
+    """
+    Lädt Konfiguration aus YAML-Datei.
+
+    Args:
+        path: Pfad zur Config-Datei (default: ~/.config/pvforecast/config.yaml)
+
+    Returns:
+        Config-Objekt mit Werten aus Datei, oder Defaults wenn nicht vorhanden
+    """
+    if path is None:
+        path = _default_config_path()
+
+    if not path.exists():
+        logger.debug(f"Keine Config-Datei gefunden: {path}")
+        return Config()
+
+    logger.info(f"Lade Config: {path}")
+
+    try:
+        with open(path) as f:
+            data = yaml.safe_load(f) or {}
+    except yaml.YAMLError as e:
+        logger.warning(f"Fehler beim Lesen der Config: {e}")
+        return Config()
+
+    # Config aus YAML-Daten erstellen
+    config = Config()
+
+    # Location
+    if "location" in data:
+        loc = data["location"]
+        if "latitude" in loc:
+            config.latitude = float(loc["latitude"])
+        if "longitude" in loc:
+            config.longitude = float(loc["longitude"])
+        if "timezone" in loc:
+            config.timezone = str(loc["timezone"])
+
+    # System
+    if "system" in data:
+        sys = data["system"]
+        if "peak_kwp" in sys:
+            config.peak_kwp = float(sys["peak_kwp"])
+        if "name" in sys:
+            config.system_name = str(sys["name"])
+
+    # Data paths
+    if "data" in data:
+        d = data["data"]
+        if "db_path" in d:
+            config.db_path = Path(d["db_path"]).expanduser()
+        if "model_path" in d:
+            config.model_path = Path(d["model_path"]).expanduser()
+
+    # API
+    if "api" in data:
+        api = data["api"]
+        if "weather_provider" in api:
+            config.weather_provider = str(api["weather_provider"])
+
+    return config
+
+
+def get_config_path() -> Path:
+    """Gibt den Standard-Pfad für die Config-Datei zurück."""
+    return _default_config_path()
 
 
 # Globale Default-Instanz

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,135 @@
+"""Tests für config.py."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from pvforecast.config import Config, load_config
+
+
+@pytest.fixture
+def sample_config_file(tmp_path):
+    """Erstellt eine Test-Config-Datei."""
+    config_data = {
+        "location": {
+            "latitude": 48.13,
+            "longitude": 11.58,
+            "timezone": "Europe/Berlin",
+        },
+        "system": {
+            "peak_kwp": 15.5,
+            "name": "München PV",
+        },
+        "data": {
+            "db_path": "/tmp/test.db",
+            "model_path": "/tmp/test.pkl",
+        },
+    }
+    config_path = tmp_path / "config.yaml"
+    with open(config_path, "w") as f:
+        yaml.dump(config_data, f)
+    return config_path
+
+
+def test_load_config_from_file(sample_config_file):
+    """Test: Config wird aus YAML-Datei geladen."""
+    config = load_config(sample_config_file)
+
+    assert config.latitude == 48.13
+    assert config.longitude == 11.58
+    assert config.peak_kwp == 15.5
+    assert config.system_name == "München PV"
+    assert config.db_path == Path("/tmp/test.db")
+
+
+def test_load_config_defaults_when_missing(tmp_path):
+    """Test: Defaults werden genutzt wenn Datei fehlt."""
+    missing_path = tmp_path / "nonexistent.yaml"
+    config = load_config(missing_path)
+
+    # Default values
+    assert config.latitude == 51.83
+    assert config.longitude == 7.28
+    assert config.peak_kwp == 9.92
+
+
+def test_load_config_partial_file(tmp_path):
+    """Test: Fehlende Felder werden mit Defaults gefüllt."""
+    config_data = {
+        "location": {
+            "latitude": 50.0,
+            # longitude fehlt
+        },
+        # system fehlt komplett
+    }
+    config_path = tmp_path / "partial.yaml"
+    with open(config_path, "w") as f:
+        yaml.dump(config_data, f)
+
+    config = load_config(config_path)
+
+    assert config.latitude == 50.0
+    assert config.longitude == 7.28  # Default
+    assert config.peak_kwp == 9.92  # Default
+
+
+def test_config_to_dict():
+    """Test: Config kann zu Dict konvertiert werden."""
+    config = Config(latitude=50.0, longitude=8.0, peak_kwp=12.0)
+    data = config.to_dict()
+
+    assert data["location"]["latitude"] == 50.0
+    assert data["location"]["longitude"] == 8.0
+    assert data["system"]["peak_kwp"] == 12.0
+
+
+def test_config_save_and_load(tmp_path):
+    """Test: Config kann gespeichert und wieder geladen werden."""
+    config = Config(
+        latitude=52.5,
+        longitude=13.4,
+        peak_kwp=20.0,
+        system_name="Berlin PV",
+    )
+
+    config_path = tmp_path / "saved.yaml"
+    config.save(config_path)
+
+    # Wieder laden
+    loaded = load_config(config_path)
+
+    assert loaded.latitude == 52.5
+    assert loaded.longitude == 13.4
+    assert loaded.peak_kwp == 20.0
+    assert loaded.system_name == "Berlin PV"
+
+
+def test_load_config_handles_invalid_yaml(tmp_path):
+    """Test: Ungültiges YAML gibt Defaults zurück."""
+    config_path = tmp_path / "invalid.yaml"
+    with open(config_path, "w") as f:
+        f.write("invalid: yaml: content: [")
+
+    config = load_config(config_path)
+
+    # Sollte Defaults nutzen
+    assert config.latitude == 51.83
+
+
+def test_config_expanduser_paths(tmp_path):
+    """Test: Pfade mit ~ werden expandiert."""
+    config_data = {
+        "data": {
+            "db_path": "~/mydata/pv.db",
+        },
+    }
+    config_path = tmp_path / "paths.yaml"
+    with open(config_path, "w") as f:
+        yaml.dump(config_data, f)
+
+    config = load_config(config_path)
+
+    # ~ sollte expandiert sein
+    assert "~" not in str(config.db_path)
+    assert str(config.db_path).startswith(str(Path.home()))


### PR DESCRIPTION
## Feature
Optionale Konfigurationsdatei statt CLI-Flags.

## Pfad
`~/.config/pvforecast/config.yaml`

## Neue Commands
```bash
pvforecast config --show   # Konfiguration anzeigen
pvforecast config --init   # Config-Datei erstellen
pvforecast config --path   # Pfad anzeigen
```

## Config-Format
```yaml
location:
  latitude: 51.83
  longitude: 7.28
  timezone: Europe/Berlin
system:
  name: Dülmen PV
  peak_kwp: 9.92
data:
  db_path: ~/.local/share/pvforecast/data.db
  model_path: ~/.local/share/pvforecast/model.pkl
```

## Priorität
CLI-Argumente überschreiben Config-Datei-Werte.

## Tests
- 7 neue Tests für Config-Loading
- Alle 20 Tests bestanden ✅

Fixes #4