### PR TITLE
Fix: Add config validation and from_dict()

### DIFF
--- a/PROJECT-STATUS.md
+++ b/PROJECT-STATUS.md
@@ -1,165 +1,96 @@
 # PV-Forecast – Projektstatus
 
-> Letzte Aktualisierung: 2026-02-04 18:09
+> Letzte Aktualisierung: 2026-02-04 20:20
 
-## 🎯 Aktueller Stand: MVP FERTIG ✅
+## 🎯 Aktueller Stand: MVP + Verbesserungen ✅
 
-Das CLI-Tool funktioniert und ist einsatzbereit.
+Das CLI-Tool funktioniert und wird aktiv verbessert.
 
-### Was funktioniert
+---
 
-| Feature | Status | Befehl |
-|---------|--------|--------|
-| Prognose heute | ✅ | `pvforecast today` |
-| Prognose morgen+ | ✅ | `pvforecast predict` |
-| CSV-Import | ✅ | `pvforecast import <csv>` |
-| Training | ✅ | `pvforecast train` |
-| Status | ✅ | `pvforecast status` |
+## 🔄 Entwicklungs-Workflow
 
-### Datenstand
+**⚠️ Vor jedem Commit: Architekten-Review!**
+
+```
+1. Issue auswählen
+2. Branch erstellen (fix/... oder feature/...)
+3. Code implementieren
+4. 🏗️ ARCHITEKTEN-REVIEW (vor Commit!)
+5. Tests schreiben/laufen lassen
+6. Commit + Push
+7. PR erstellen
+8. CI abwarten
+9. Merge + Cleanup
+```
+
+---
+
+## ✅ Erledigte Issues
+
+| # | Titel | PR |
+|---|-------|-----|
+| #1 | Lücken-Erkennung | #7 ✅ |
+| #2 | Retry-Logic | #8 ✅ |
+| #4 | Config-File (YAML) | #9 ✅ |
+
+## 🔓 Offene Issues
+
+| # | Titel | Prio |
+|---|-------|------|
+| #10 | Config-Validierung | 🔴 Hoch |
+| #11 | Bulk Insert Performance | 🔴 Hoch |
+| #3 | evaluate (Backtesting) | 🟡 Mittel |
+| #5 | Tests vervollständigen | 🟡 Mittel |
+| #6 | XGBoost | 🟢 Niedrig |
+| #12 | Retry 429 + Jitter | 🟢 Niedrig |
+
+---
+
+## 📊 Datenstand
 
 | Daten | Anzahl | Zeitraum |
 |-------|--------|----------|
-| PV-Readings | 61.354 | 2019-01-01 bis 2025-12-31 |
-| Wetter | 61.320 | 2018-12-31 bis 2026-01-01 |
+| PV-Readings | 61.354 | 2019-2025 |
+| Wetter | 61.320 | 2018-2025 |
 
-### Modell-Performance
+## 🤖 Modell-Performance
 
-| Metrik | Wert | Notiz |
-|--------|------|-------|
-| **MAE** | **183 W** | ~1.8% von Peak (sehr gut) |
-| **MAPE** | **45.6%** | Nur für Stunden >100W berechnet |
-| Trainingsdaten | 61.068 | 6 Jahre |
-
----
-
-## 📂 Projektstruktur
-
-```
-~/projects/pv-forecast/
-├── SPEC.md              # Vollständige Spezifikation
-├── PROJECT-STATUS.md    # Diese Datei
-├── README.md            # Dokumentation
-├── pyproject.toml       # Python Projekt-Config
-├── src/pvforecast/      # Source Code
-│   ├── cli.py           # CLI Interface
-│   ├── config.py        # Konfiguration
-│   ├── db.py            # SQLite Layer
-│   ├── data_loader.py   # E3DC CSV Import
-│   ├── weather.py       # Open-Meteo Client
-│   └── model.py         # ML (RandomForest)
-└── tests/               # Pytest Tests
-```
-
-### Daten-Speicherorte
-
-```
-~/.local/share/pvforecast/
-├── data.db              # SQLite mit PV + Wetter
-└── model.pkl            # Trainiertes Modell
-```
+| Metrik | Wert |
+|--------|------|
+| **MAE** | 183 W |
+| **MAPE** | 45.6% |
 
 ---
 
-## 🔧 Entwicklungsumgebung
+## 🚀 Befehle
 
 ```bash
-cd ~/projects/pv-forecast
-source .venv/bin/activate
-```
+cd ~/projects/pv-forecast && source .venv/bin/activate
 
-Python: 3.9.6  
-Dependencies: pandas, scikit-learn, httpx
-
----
-
-## 🚀 Verwendung
-
-### Prognose für heute
-
-```bash
-pvforecast today
-```
-
-Zeigt den **ganzen heutigen Tag** (vergangene + kommende Stunden) mit:
-- Erwarteter Tagesertrag in kWh
-- Stundenwerte mit Wetter-Emoji
-- Aktuelle Stunde markiert (◄)
-
-### Prognose für morgen + übermorgen
-
-```bash
-# Standard: morgen + übermorgen (2 volle Tage)
-pvforecast predict
-
-# Mehr Tage
-pvforecast predict --days 3
-
-# Als JSON
-pvforecast predict --format json
-```
-
-### Daten importieren & trainieren
-
-```bash
-# Neue CSV importieren
-pvforecast import ~/Downloads/E3DC-Export-2026.csv
-
-# Modell neu trainieren
-pvforecast train
-```
-
-### Status prüfen
-
-```bash
-pvforecast status
+pvforecast today              # Prognose heute
+pvforecast predict            # morgen + übermorgen
+pvforecast predict --days 3   # 3 Tage
+pvforecast status             # DB-Status
+pvforecast train              # Modell trainieren
+pvforecast import <csv>       # E3DC CSV importieren
+pvforecast config --show      # Config anzeigen
+pvforecast config --init      # Config-Datei erstellen
 ```
 
 ---
 
-## 📋 Offene TODOs
+## 📂 Struktur
 
-### Priorität 1 (Qualität)
-- [ ] **Lücken-Erkennung**: `ensure_weather_history` findet keine Lücken in der Mitte
-- [ ] **Retry-Logic**: Bei API-Timeouts automatisch wiederholen
-
-### Priorität 2 (Features)
-- [ ] `pvforecast evaluate` implementieren (Backtesting)
-- [ ] Config-File Support (optional)
-
-### Priorität 3 (Polish)
-- [ ] pytest Tests durchlaufen lassen
-- [ ] Git Repository auf GitHub anlegen
-- [ ] XGBoost als Alternative zu RandomForest
-
-### Priorität 4 (Später)
-- [ ] GUI (Web oder TUI)
-- [ ] Automatische tägliche Prognose (Cronjob)
-- [ ] Vergleich Prognose vs. Realität
+```
+~/.config/pvforecast/config.yaml    # Konfiguration
+~/.local/share/pvforecast/data.db   # Datenbank
+~/.local/share/pvforecast/model.pkl # Trainiertes Modell
+```
 
 ---
 
-## ✅ Erledigte TODOs
+## 🔗 Links
 
-- [x] MAPE-Fix: Nur Stunden >100W für Berechnung
-- [x] Volle Tage: `--days 2` statt `--hours 48` (morgen + übermorgen)
-- [x] `pvforecast today`: Ganzer heutiger Tag mit past_hours API
-
----
-
-## 📝 Entwicklungshistorie
-
-### 2026-02-04: MVP erstellt
-- Fachexperten-Phase: Requirements mit Marcus geklärt
-- Architekten-Phase: SPEC.md erstellt, Entscheidungen getroffen
-- Entwickler-Phase: Alle Module implementiert
-- Wetterdaten für 2019-2025 geladen
-- Modell trainiert: MAE 183W, MAPE 45.6%
-- **Fixes:** 
-  - MAPE-Schwellwert 100W
-  - Volle Tage statt 48h
-  - `today` Befehl mit past_hours für ganzen Tag
-
----
-
-*Diese Datei dient als Einstiegspunkt für neue Sessions.*
+- **GitHub:** https://github.com/jarvis-schlappa/pv-forecast
+- **CI:** GitHub Actions (Python 3.9-3.12)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from pvforecast.config import Config, load_config
+from pvforecast.config import Config, ConfigValidationError, load_config
 
 
 @pytest.fixture
@@ -133,3 +133,151 @@ def test_config_expanduser_paths(tmp_path):
     # ~ sollte expandiert sein
     assert "~" not in str(config.db_path)
     assert str(config.db_path).startswith(str(Path.home()))
+
+
+# === Validierungs-Tests ===
+
+
+class TestConfigValidation:
+    """Tests für Config-Validierung."""
+
+    def test_valid_config(self):
+        """Test: Gültige Config wird akzeptiert."""
+        config = Config(latitude=50.0, longitude=10.0, peak_kwp=10.0)
+        assert config.latitude == 50.0
+
+    def test_invalid_latitude_too_high(self):
+        """Test: Latitude > 90 wird abgelehnt."""
+        with pytest.raises(ConfigValidationError) as exc_info:
+            Config(latitude=91.0)
+        assert "latitude" in str(exc_info.value)
+
+    def test_invalid_latitude_too_low(self):
+        """Test: Latitude < -90 wird abgelehnt."""
+        with pytest.raises(ConfigValidationError) as exc_info:
+            Config(latitude=-91.0)
+        assert "latitude" in str(exc_info.value)
+
+    def test_invalid_longitude_too_high(self):
+        """Test: Longitude > 180 wird abgelehnt."""
+        with pytest.raises(ConfigValidationError) as exc_info:
+            Config(longitude=181.0)
+        assert "longitude" in str(exc_info.value)
+
+    def test_invalid_longitude_too_low(self):
+        """Test: Longitude < -180 wird abgelehnt."""
+        with pytest.raises(ConfigValidationError) as exc_info:
+            Config(longitude=-181.0)
+        assert "longitude" in str(exc_info.value)
+
+    def test_invalid_peak_kwp_zero(self):
+        """Test: peak_kwp = 0 wird abgelehnt."""
+        with pytest.raises(ConfigValidationError) as exc_info:
+            Config(peak_kwp=0)
+        assert "peak_kwp" in str(exc_info.value)
+
+    def test_invalid_peak_kwp_negative(self):
+        """Test: Negative peak_kwp wird abgelehnt."""
+        with pytest.raises(ConfigValidationError) as exc_info:
+            Config(peak_kwp=-5.0)
+        assert "peak_kwp" in str(exc_info.value)
+
+    def test_invalid_system_name_empty(self):
+        """Test: Leerer system_name wird abgelehnt."""
+        with pytest.raises(ConfigValidationError) as exc_info:
+            Config(system_name="")
+        assert "system_name" in str(exc_info.value)
+
+    def test_invalid_system_name_whitespace(self):
+        """Test: system_name nur aus Whitespace wird abgelehnt."""
+        with pytest.raises(ConfigValidationError) as exc_info:
+            Config(system_name="   ")
+        assert "system_name" in str(exc_info.value)
+
+    def test_boundary_latitude_valid(self):
+        """Test: Grenzwerte für latitude sind gültig."""
+        config_north = Config(latitude=90.0)
+        config_south = Config(latitude=-90.0)
+        assert config_north.latitude == 90.0
+        assert config_south.latitude == -90.0
+
+    def test_boundary_longitude_valid(self):
+        """Test: Grenzwerte für longitude sind gültig."""
+        config_east = Config(longitude=180.0)
+        config_west = Config(longitude=-180.0)
+        assert config_east.longitude == 180.0
+        assert config_west.longitude == -180.0
+
+
+class TestConfigFromDict:
+    """Tests für Config.from_dict()."""
+
+    def test_from_dict_complete(self):
+        """Test: Vollständiges Dict wird korrekt geparst."""
+        data = {
+            "location": {"latitude": 48.0, "longitude": 11.0, "timezone": "UTC"},
+            "system": {"peak_kwp": 15.0, "name": "Test PV"},
+            "data": {"db_path": "/tmp/db.sqlite", "model_path": "/tmp/model.pkl"},
+            "api": {"weather_provider": "test-api"},
+        }
+        config = Config.from_dict(data)
+
+        assert config.latitude == 48.0
+        assert config.longitude == 11.0
+        assert config.timezone == "UTC"
+        assert config.peak_kwp == 15.0
+        assert config.system_name == "Test PV"
+        assert config.db_path == Path("/tmp/db.sqlite")
+        assert config.weather_provider == "test-api"
+
+    def test_from_dict_empty(self):
+        """Test: Leeres Dict gibt Defaults."""
+        config = Config.from_dict({})
+        assert config.latitude == 51.83
+        assert config.peak_kwp == 9.92
+
+    def test_from_dict_partial(self):
+        """Test: Teilweises Dict merged mit Defaults."""
+        data = {"location": {"latitude": 50.0}}
+        config = Config.from_dict(data)
+
+        assert config.latitude == 50.0
+        assert config.longitude == 7.28  # Default
+
+    def test_from_dict_validates(self):
+        """Test: from_dict validiert auch."""
+        data = {"location": {"latitude": 999.0}}
+        with pytest.raises(ConfigValidationError):
+            Config.from_dict(data)
+
+    def test_from_dict_to_dict_roundtrip(self):
+        """Test: from_dict(to_dict()) ist identisch."""
+        original = Config(
+            latitude=52.5,
+            longitude=13.4,
+            peak_kwp=20.0,
+            system_name="Berlin PV",
+        )
+
+        roundtrip = Config.from_dict(original.to_dict())
+
+        assert roundtrip.latitude == original.latitude
+        assert roundtrip.longitude == original.longitude
+        assert roundtrip.peak_kwp == original.peak_kwp
+        assert roundtrip.system_name == original.system_name
+
+
+class TestLoadConfigValidation:
+    """Tests für Validierung beim Laden."""
+
+    def test_load_invalid_config_raises(self, tmp_path):
+        """Test: Ungültige Config-Datei wirft Fehler."""
+        config_data = {
+            "location": {"latitude": 999.0},  # Ungültig!
+        }
+        config_path = tmp_path / "invalid_values.yaml"
+        with open(config_path, "w") as f:
+            yaml.dump(config_data, f)
+
+        with pytest.raises(ConfigValidationError):
+            load_config(config_path)


### PR DESCRIPTION
## Problem
Ungültige Config-Werte wurden akzeptiert (z.B. latitude=999).

## Lösung

### 1. Validierung via `__post_init__`
- latitude: -90 bis 90
- longitude: -180 bis 180
- peak_kwp: muss positiv sein
- system_name: darf nicht leer sein

### 2. `Config.from_dict()` Klassenmethode
- Inverse von `to_dict()`
- Ermöglicht Roundtrip: `Config.from_dict(config.to_dict())`
- `load_config()` nutzt jetzt `from_dict()` (vereinfacht)

### 3. `ConfigValidationError`
Eigene Exception-Klasse für Validierungsfehler.

## Tests
- 17 neue Tests für Validierung
- Boundary-Tests (Grenzwerte)
- Roundtrip-Test
- Alle 37 Tests bestanden ✅

## Architekten-Review
✅ Freigegeben

Fixes #10