### PR TITLE
fix: CLI output cleanup - reduce verbosity, hide HTTP logs

### DIFF
--- a/src/pvforecast/cli.py
+++ b/src/pvforecast/cli.py
@@ -416,9 +416,15 @@ def cmd_tune(args: argparse.Namespace, config: Config) -> int:
     print()
     print("🎯 Beste Parameter:")
     for param, value in best_params.items():
-        if isinstance(value, float):
-            print(f"   {param}: {value:.4f}")
-        else:
+        # np.float64 und andere float-artige Typen erkennen
+        try:
+            float_val = float(value)
+            # Prüfen ob es wirklich ein Float ist (nicht int als float)
+            if float_val != int(float_val):
+                print(f"   {param}: {float_val:.4f}")
+            else:
+                print(f"   {param}: {int(float_val)}")
+        except (TypeError, ValueError):
             print(f"   {param}: {value}")
     print()
     print(f"💾 Modell gespeichert: {config.model_path}")
@@ -808,6 +814,11 @@ def main() -> int:
         level=level,
         format="%(message)s" if not args.verbose else "%(levelname)s: %(message)s",
     )
+
+    # HTTP-Logs nur bei --verbose anzeigen
+    if not args.verbose:
+        logging.getLogger("httpx").setLevel(logging.WARNING)
+        logging.getLogger("httpcore").setLevel(logging.WARNING)
 
     try:
         return _run_command(args, parser)

--- a/src/pvforecast/data_loader.py
+++ b/src/pvforecast/data_loader.py
@@ -56,7 +56,7 @@ def load_e3dc_csv(csv_path: Path) -> pd.DataFrame:
     if not csv_path.exists():
         raise DataImportError(f"CSV nicht gefunden: {csv_path}")
 
-    logger.info(f"Lade CSV: {csv_path}")
+    logger.debug(f"Lade CSV: {csv_path}")
 
     try:
         df = pd.read_csv(
@@ -119,7 +119,7 @@ def load_e3dc_csv(csv_path: Path) -> pd.DataFrame:
         if col in df.columns:
             df[col] = pd.to_numeric(df[col], errors="coerce").fillna(0).astype(int)
 
-    logger.info(f"Geladen: {len(df)} Datensätze")
+    logger.debug(f"Geladen: {len(df)} Datensätze")
     return df
 
 
@@ -165,7 +165,7 @@ def import_to_db(df: pd.DataFrame, db: Database) -> int:
             except Exception as e:
                 logger.warning(f"Fehler bei Zeile {row.get('timestamp')}: {e}")
 
-    logger.info(f"Importiert: {inserted} neue Datensätze")
+    logger.debug(f"Importiert: {inserted} neue Datensätze")
     return inserted
 
 

--- a/src/pvforecast/model.py
+++ b/src/pvforecast/model.py
@@ -482,7 +482,7 @@ def tune(
     }
 
     logger.info("Tuning abgeschlossen!")
-    logger.info(f"Beste Parameter: {best_params}")
+    logger.debug(f"Beste Parameter (raw): {best_params}")
     logger.info(f"CV-Score (MAE): {-search.best_score_:.0f}W")
     logger.info(f"Test-MAPE: {mape:.1f}%, Test-MAE: {mae:.0f}W")
 

--- a/src/pvforecast/weather.py
+++ b/src/pvforecast/weather.py
@@ -433,7 +433,7 @@ def ensure_weather_history(
             else:
                 break
 
-        logger.info(f"Lade Wetterdaten: {chunk_start} bis {chunk_end}")
+        logger.debug(f"Lade Wetterdaten: {chunk_start} bis {chunk_end}")
         try:
             df = fetch_historical(lat, lon, chunk_start, chunk_end)
             loaded = save_weather_to_db(df, db)


### PR DESCRIPTION
## Problem
CLI-Ausgabe war zu verbose:
- 4-5 Zeilen pro CSV-Datei beim Import
- Doppelte Wetter-Meldungen
- HTTP-Requests im Default-Output
- `np.float64(...)` in Parameter-Ausgabe

## Lösung
- Detail-Logs (Lade CSV, Geladen, Importiert) auf DEBUG Level
- httpx/httpcore Logs verstecken (nur bei --verbose)
- Redundante "Lade Wetterdaten" Meldung entfernt
- Parameter-Ausgabe: np.float64 → saubere Floats (0.8782)

## Vorher/Nachher

**Import (vorher: 5 Zeilen/Datei):**
```
Lade CSV: .../E3DC-Export-2019.csv
1 Zeilen wegen Zeitumstellung übersprungen
Geladen: 8758 Datensätze
Importiert: 8758 neue Datensätze
E3DC-Export-2019.csv: 8758 neue Datensätze
```

**Import (nachher: 2 Zeilen/Datei):**
```
1 Zeilen wegen Zeitumstellung übersprungen
E3DC-Export-2019.csv: 8758 neue Datensätze
```

**Parameter (vorher):**
```
colsample_bytree: np.float64(0.878206434570451)
```

**Parameter (nachher):**
```
colsample_bytree: 0.8782
```

## Tests
- 158 Tests bestanden
- Manuell getestet: Import, Wetter-Download, Tuning

Closes #45