### PR TITLE
feat: Add geocoding module for location lookup

### DIFF
--- a/src/pvforecast/geocoding.py
+++ b/src/pvforecast/geocoding.py
@@ -1,0 +1,285 @@
+"""Geocoding via OpenStreetMap Nominatim API.
+
+Ermöglicht die Umwandlung von PLZ/Ortsnamen in Koordinaten.
+Beachtet Nominatim Usage Policy: max 1 Request/Sekunde, User-Agent erforderlich.
+
+Dokumentation: https://nominatim.org/release-docs/latest/api/Search/
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+
+import httpx
+
+from pvforecast import __version__
+
+logger = logging.getLogger(__name__)
+
+# Nominatim API Konfiguration
+NOMINATIM_URL = "https://nominatim.openstreetmap.org/search"
+USER_AGENT = f"pvforecast/{__version__} (https://github.com/jarvis-schlappa/pv-forecast)"
+
+# Rate-Limiting: Zeitpunkt des letzten Requests
+_last_request_time: float = 0.0
+_MIN_REQUEST_INTERVAL = 1.0  # Sekunden (Nominatim Policy)
+
+# Timeout und Retry-Konfiguration
+DEFAULT_TIMEOUT = 10.0  # Sekunden
+MAX_RETRIES = 3
+RETRY_DELAY = 2.0  # Sekunden zwischen Retries
+
+
+class GeocodingError(Exception):
+    """Fehler bei der Geocoding-Abfrage."""
+
+    pass
+
+
+@dataclass
+class GeoResult:
+    """Ergebnis einer Geocoding-Abfrage.
+
+    Attributes:
+        latitude: Breitengrad (WGS84)
+        longitude: Längengrad (WGS84)
+        display_name: Vollständiger Anzeigename von Nominatim
+        city: Stadt/Gemeinde (falls verfügbar)
+        state: Bundesland/Region (falls verfügbar)
+        country: Land (falls verfügbar)
+        country_code: ISO 3166-1 alpha-2 Ländercode
+    """
+
+    latitude: float
+    longitude: float
+    display_name: str
+    city: str | None = None
+    state: str | None = None
+    country: str | None = None
+    country_code: str | None = None
+
+    def short_name(self) -> str:
+        """Kurzer Anzeigename (Stadt, Region)."""
+        parts = []
+        if self.city:
+            parts.append(self.city)
+        if self.state:
+            parts.append(self.state)
+        if not parts and self.display_name:
+            # Fallback: Erste zwei Teile des display_name
+            display_parts = self.display_name.split(", ")[:2]
+            return ", ".join(display_parts)
+        return ", ".join(parts)
+
+
+def _enforce_rate_limit() -> None:
+    """Stellt sicher, dass Rate-Limit eingehalten wird."""
+    global _last_request_time
+    now = time.monotonic()
+    elapsed = now - _last_request_time
+    if elapsed < _MIN_REQUEST_INTERVAL:
+        sleep_time = _MIN_REQUEST_INTERVAL - elapsed
+        logger.debug(f"Rate-Limit: Warte {sleep_time:.2f}s")
+        time.sleep(sleep_time)
+    _last_request_time = time.monotonic()
+
+
+def _parse_address(address: dict) -> tuple[str | None, str | None, str | None, str | None]:
+    """Extrahiert Stadt, Bundesland, Land und Ländercode aus Nominatim-Adresse.
+
+    Args:
+        address: Adress-Dictionary aus Nominatim-Response
+
+    Returns:
+        Tuple (city, state, country, country_code)
+    """
+    # Stadt: verschiedene Felder probieren (Priorität)
+    city = (
+        address.get("city")
+        or address.get("town")
+        or address.get("village")
+        or address.get("municipality")
+    )
+
+    state = address.get("state")
+    country = address.get("country")
+    country_code = address.get("country_code", "").upper() or None
+
+    return city, state, country, country_code
+
+
+def geocode(
+    query: str,
+    country_codes: str | None = "de,at,ch",
+    timeout: float = DEFAULT_TIMEOUT,
+) -> GeoResult | None:
+    """Sucht Koordinaten für eine PLZ oder einen Ortsnamen.
+
+    Args:
+        query: Suchbegriff (PLZ, Ortsname, oder Kombination wie "48249 Dülmen")
+        country_codes: Komma-getrennte ISO 3166-1 alpha-2 Ländercodes zur Einschränkung.
+                      Default: "de,at,ch" (Deutschland, Österreich, Schweiz).
+                      None für weltweite Suche.
+        timeout: Timeout in Sekunden
+
+    Returns:
+        GeoResult bei Erfolg, None wenn nichts gefunden
+
+    Raises:
+        GeocodingError: Bei API-Fehlern oder Netzwerkproblemen
+    """
+    if not query or not query.strip():
+        return None
+
+    query = query.strip()
+    logger.debug(f"Geocoding: '{query}'")
+
+    params: dict[str, str | int] = {
+        "q": query,
+        "format": "jsonv2",
+        "addressdetails": 1,
+        "limit": 1,
+    }
+
+    if country_codes:
+        params["countrycodes"] = country_codes
+
+    headers = {
+        "User-Agent": USER_AGENT,
+        "Accept": "application/json",
+    }
+
+    last_error: Exception | None = None
+
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            _enforce_rate_limit()
+
+            with httpx.Client(timeout=timeout) as client:
+                response = client.get(NOMINATIM_URL, params=params, headers=headers)
+                response.raise_for_status()
+                data = response.json()
+
+            if not data:
+                logger.debug(f"Keine Ergebnisse für '{query}'")
+                return None
+
+            result = data[0]
+            address = result.get("address", {})
+            city, state, country, country_code = _parse_address(address)
+
+            geo_result = GeoResult(
+                latitude=float(result["lat"]),
+                longitude=float(result["lon"]),
+                display_name=result.get("display_name", ""),
+                city=city,
+                state=state,
+                country=country,
+                country_code=country_code,
+            )
+
+            logger.debug(
+                f"Gefunden: {geo_result.short_name()} "
+                f"({geo_result.latitude}, {geo_result.longitude})"
+            )
+            return geo_result
+
+        except httpx.TimeoutException as e:
+            last_error = e
+            logger.warning(f"Timeout bei Geocoding (Versuch {attempt}/{MAX_RETRIES})")
+            if attempt < MAX_RETRIES:
+                time.sleep(RETRY_DELAY)
+
+        except httpx.HTTPStatusError as e:
+            # Bei 429 (Too Many Requests) länger warten
+            if e.response.status_code == 429:
+                last_error = e
+                logger.warning(f"Rate-Limit erreicht (Versuch {attempt}/{MAX_RETRIES})")
+                if attempt < MAX_RETRIES:
+                    time.sleep(RETRY_DELAY * 2)
+            else:
+                raise GeocodingError(f"HTTP-Fehler {e.response.status_code}: {e}") from e
+
+        except httpx.RequestError as e:
+            last_error = e
+            logger.warning(f"Netzwerkfehler bei Geocoding (Versuch {attempt}/{MAX_RETRIES}): {e}")
+            if attempt < MAX_RETRIES:
+                time.sleep(RETRY_DELAY)
+
+    # Alle Retries fehlgeschlagen
+    raise GeocodingError(f"Geocoding fehlgeschlagen nach {MAX_RETRIES} Versuchen: {last_error}")
+
+
+def geocode_postal_code(
+    postal_code: str,
+    country_code: str = "de",
+    timeout: float = DEFAULT_TIMEOUT,
+) -> GeoResult | None:
+    """Sucht Koordinaten für eine Postleitzahl.
+
+    Spezialisierte Funktion für PLZ-Suche mit besserem Matching.
+
+    Args:
+        postal_code: Postleitzahl (z.B. "48249")
+        country_code: ISO 3166-1 alpha-2 Ländercode (default: "de")
+        timeout: Timeout in Sekunden
+
+    Returns:
+        GeoResult bei Erfolg, None wenn nichts gefunden
+
+    Raises:
+        GeocodingError: Bei API-Fehlern
+    """
+    # PLZ normalisieren (nur Ziffern/Buchstaben)
+    postal_code = "".join(c for c in postal_code if c.isalnum())
+
+    if not postal_code:
+        return None
+
+    # Strukturierte Suche: "postalcode" Parameter für besseres Matching
+    params: dict[str, str | int] = {
+        "postalcode": postal_code,
+        "country": country_code,
+        "format": "jsonv2",
+        "addressdetails": 1,
+        "limit": 1,
+    }
+
+    headers = {
+        "User-Agent": USER_AGENT,
+        "Accept": "application/json",
+    }
+
+    try:
+        _enforce_rate_limit()
+
+        with httpx.Client(timeout=timeout) as client:
+            response = client.get(NOMINATIM_URL, params=params, headers=headers)
+            response.raise_for_status()
+            data = response.json()
+
+        if not data:
+            # Fallback: Freie Suche mit PLZ
+            logger.debug("Strukturierte PLZ-Suche ohne Ergebnis, versuche Freitext")
+            return geocode(postal_code, country_codes=country_code, timeout=timeout)
+
+        result = data[0]
+        address = result.get("address", {})
+        city, state, country, cc = _parse_address(address)
+
+        return GeoResult(
+            latitude=float(result["lat"]),
+            longitude=float(result["lon"]),
+            display_name=result.get("display_name", ""),
+            city=city,
+            state=state,
+            country=country,
+            country_code=cc,
+        )
+
+    except httpx.RequestError as e:
+        raise GeocodingError(f"Netzwerkfehler: {e}") from e
+    except httpx.HTTPStatusError as e:
+        raise GeocodingError(f"HTTP-Fehler {e.response.status_code}") from e

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -1,0 +1,445 @@
+"""Tests für das Geocoding-Modul."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from pvforecast.geocoding import (
+    GeocodingError,
+    GeoResult,
+    _parse_address,
+    geocode,
+    geocode_postal_code,
+)
+
+
+class TestGeoResult:
+    """Tests für die GeoResult Dataclass."""
+
+    def test_creation(self):
+        """Test: GeoResult kann erstellt werden."""
+        result = GeoResult(
+            latitude=51.83,
+            longitude=7.28,
+            display_name="Dülmen, Coesfeld, NRW, Deutschland",
+            city="Dülmen",
+            state="Nordrhein-Westfalen",
+            country="Deutschland",
+            country_code="DE",
+        )
+        assert result.latitude == 51.83
+        assert result.longitude == 7.28
+        assert result.city == "Dülmen"
+        assert result.country_code == "DE"
+
+    def test_short_name_with_city_and_state(self):
+        """Test: short_name mit Stadt und Bundesland."""
+        result = GeoResult(
+            latitude=51.83,
+            longitude=7.28,
+            display_name="Dülmen, Coesfeld, NRW, Deutschland",
+            city="Dülmen",
+            state="NRW",
+        )
+        assert result.short_name() == "Dülmen, NRW"
+
+    def test_short_name_city_only(self):
+        """Test: short_name nur mit Stadt."""
+        result = GeoResult(
+            latitude=51.83,
+            longitude=7.28,
+            display_name="Dülmen, Deutschland",
+            city="Dülmen",
+        )
+        assert result.short_name() == "Dülmen"
+
+    def test_short_name_fallback_to_display_name(self):
+        """Test: short_name Fallback auf display_name."""
+        result = GeoResult(
+            latitude=51.83,
+            longitude=7.28,
+            display_name="Dülmen, Coesfeld, NRW, Deutschland",
+        )
+        assert result.short_name() == "Dülmen, Coesfeld"
+
+    def test_short_name_empty(self):
+        """Test: short_name bei leeren Feldern."""
+        result = GeoResult(
+            latitude=51.83,
+            longitude=7.28,
+            display_name="",
+        )
+        assert result.short_name() == ""
+
+
+class TestParseAddress:
+    """Tests für _parse_address Hilfsfunktion."""
+
+    def test_full_address(self):
+        """Test: Vollständige Adresse parsen."""
+        address = {
+            "city": "Dülmen",
+            "state": "Nordrhein-Westfalen",
+            "country": "Deutschland",
+            "country_code": "de",
+        }
+        city, state, country, cc = _parse_address(address)
+        assert city == "Dülmen"
+        assert state == "Nordrhein-Westfalen"
+        assert country == "Deutschland"
+        assert cc == "DE"
+
+    def test_town_instead_of_city(self):
+        """Test: 'town' wird als Stadt erkannt."""
+        address = {"town": "Kleinstadt", "country_code": "de"}
+        city, _, _, _ = _parse_address(address)
+        assert city == "Kleinstadt"
+
+    def test_village_instead_of_city(self):
+        """Test: 'village' wird als Stadt erkannt."""
+        address = {"village": "Dorf", "country_code": "at"}
+        city, _, _, _ = _parse_address(address)
+        assert city == "Dorf"
+
+    def test_municipality_instead_of_city(self):
+        """Test: 'municipality' wird als Stadt erkannt."""
+        address = {"municipality": "Gemeinde"}
+        city, _, _, _ = _parse_address(address)
+        assert city == "Gemeinde"
+
+    def test_empty_address(self):
+        """Test: Leere Adresse."""
+        city, state, country, cc = _parse_address({})
+        assert city is None
+        assert state is None
+        assert country is None
+        assert cc is None
+
+
+class TestGeocode:
+    """Tests für die geocode Funktion."""
+
+    @patch("pvforecast.geocoding.httpx.Client")
+    @patch("pvforecast.geocoding._enforce_rate_limit")
+    def test_successful_geocode(self, mock_rate_limit, mock_client_class):
+        """Test: Erfolgreiche Geocoding-Abfrage."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            {
+                "lat": "51.8333",
+                "lon": "7.2833",
+                "display_name": "Dülmen, Coesfeld, NRW, Deutschland",
+                "address": {
+                    "city": "Dülmen",
+                    "state": "Nordrhein-Westfalen",
+                    "country": "Deutschland",
+                    "country_code": "de",
+                },
+            }
+        ]
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_class.return_value = mock_client
+
+        result = geocode("48249 Dülmen")
+
+        assert result is not None
+        assert result.latitude == 51.8333
+        assert result.longitude == 7.2833
+        assert result.city == "Dülmen"
+        assert result.country_code == "DE"
+
+    @patch("pvforecast.geocoding.httpx.Client")
+    @patch("pvforecast.geocoding._enforce_rate_limit")
+    def test_no_results(self, mock_rate_limit, mock_client_class):
+        """Test: Keine Ergebnisse gefunden."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = []
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_class.return_value = mock_client
+
+        result = geocode("xyznonexistent12345")
+
+        assert result is None
+
+    def test_empty_query(self):
+        """Test: Leerer Suchbegriff."""
+        result = geocode("")
+        assert result is None
+
+        result = geocode("   ")
+        assert result is None
+
+    @patch("pvforecast.geocoding.httpx.Client")
+    @patch("pvforecast.geocoding._enforce_rate_limit")
+    @patch("pvforecast.geocoding.time.sleep")
+    def test_timeout_with_retry(self, mock_sleep, mock_rate_limit, mock_client_class):
+        """Test: Timeout mit Retry."""
+        mock_client = MagicMock()
+        mock_client.get.side_effect = httpx.TimeoutException("Timeout")
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_class.return_value = mock_client
+
+        with pytest.raises(GeocodingError) as exc_info:
+            geocode("Dülmen")
+
+        assert "fehlgeschlagen nach 3 Versuchen" in str(exc_info.value)
+        assert mock_client.get.call_count == 3  # 3 Retries
+
+    @patch("pvforecast.geocoding.httpx.Client")
+    @patch("pvforecast.geocoding._enforce_rate_limit")
+    def test_http_error(self, mock_rate_limit, mock_client_class):
+        """Test: HTTP-Fehler (nicht 429)."""
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Server Error", request=MagicMock(), response=mock_response
+        )
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_class.return_value = mock_client
+
+        with pytest.raises(GeocodingError) as exc_info:
+            geocode("Dülmen")
+
+        assert "HTTP-Fehler 500" in str(exc_info.value)
+
+    @patch("pvforecast.geocoding.httpx.Client")
+    @patch("pvforecast.geocoding._enforce_rate_limit")
+    @patch("pvforecast.geocoding.time.sleep")
+    def test_rate_limit_429_with_retry(self, mock_sleep, mock_rate_limit, mock_client_class):
+        """Test: Rate-Limit (429) mit Retry."""
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Too Many Requests", request=MagicMock(), response=mock_response
+        )
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_class.return_value = mock_client
+
+        with pytest.raises(GeocodingError) as exc_info:
+            geocode("Dülmen")
+
+        assert "fehlgeschlagen nach 3 Versuchen" in str(exc_info.value)
+        assert mock_client.get.call_count == 3
+
+    @patch("pvforecast.geocoding.httpx.Client")
+    @patch("pvforecast.geocoding._enforce_rate_limit")
+    def test_country_codes_filter(self, mock_rate_limit, mock_client_class):
+        """Test: Country-Codes werden als Parameter übergeben."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = []
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_class.return_value = mock_client
+
+        geocode("Berlin", country_codes="de")
+
+        # Prüfe dass countrycodes in params enthalten ist
+        call_args = mock_client.get.call_args
+        assert call_args[1]["params"]["countrycodes"] == "de"
+
+    @patch("pvforecast.geocoding.httpx.Client")
+    @patch("pvforecast.geocoding._enforce_rate_limit")
+    def test_no_country_codes(self, mock_rate_limit, mock_client_class):
+        """Test: Weltweite Suche ohne Country-Code-Filter."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = []
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_class.return_value = mock_client
+
+        geocode("New York", country_codes=None)
+
+        # countrycodes sollte NICHT in params sein
+        call_args = mock_client.get.call_args
+        assert "countrycodes" not in call_args[1]["params"]
+
+
+class TestGeocodePostalCode:
+    """Tests für die geocode_postal_code Funktion."""
+
+    @patch("pvforecast.geocoding.httpx.Client")
+    @patch("pvforecast.geocoding._enforce_rate_limit")
+    def test_successful_postal_code(self, mock_rate_limit, mock_client_class):
+        """Test: Erfolgreiche PLZ-Suche."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            {
+                "lat": "51.8333",
+                "lon": "7.2833",
+                "display_name": "48249, Dülmen, NRW, Deutschland",
+                "address": {
+                    "city": "Dülmen",
+                    "postcode": "48249",
+                    "country_code": "de",
+                },
+            }
+        ]
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_class.return_value = mock_client
+
+        result = geocode_postal_code("48249")
+
+        assert result is not None
+        assert result.city == "Dülmen"
+
+    @patch("pvforecast.geocoding.geocode")
+    @patch("pvforecast.geocoding.httpx.Client")
+    @patch("pvforecast.geocoding._enforce_rate_limit")
+    def test_fallback_to_geocode(self, mock_rate_limit, mock_client_class, mock_geocode):
+        """Test: Fallback auf geocode() wenn strukturierte Suche nichts findet."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = []  # Keine Ergebnisse
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_class.return_value = mock_client
+
+        mock_geocode.return_value = GeoResult(
+            latitude=51.83, longitude=7.28, display_name="Fallback"
+        )
+
+        result = geocode_postal_code("48249")
+
+        assert result is not None
+        mock_geocode.assert_called_once()
+
+    def test_empty_postal_code(self):
+        """Test: Leere PLZ."""
+        result = geocode_postal_code("")
+        assert result is None
+
+    def test_postal_code_normalization(self):
+        """Test: PLZ wird normalisiert (Leerzeichen/Sonderzeichen entfernt)."""
+        with patch("pvforecast.geocoding.httpx.Client") as mock_client_class:
+            mock_response = MagicMock()
+            mock_response.json.return_value = []
+            mock_response.raise_for_status = MagicMock()
+
+            mock_client = MagicMock()
+            mock_client.get.return_value = mock_response
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=False)
+            mock_client_class.return_value = mock_client
+
+            with patch("pvforecast.geocoding._enforce_rate_limit"):
+                with patch("pvforecast.geocoding.geocode", return_value=None):
+                    geocode_postal_code("48-249")
+
+            # PLZ sollte normalisiert sein
+            call_args = mock_client.get.call_args
+            assert call_args[1]["params"]["postalcode"] == "48249"
+
+    @patch("pvforecast.geocoding.httpx.Client")
+    @patch("pvforecast.geocoding._enforce_rate_limit")
+    def test_network_error(self, mock_rate_limit, mock_client_class):
+        """Test: Netzwerkfehler."""
+        mock_client = MagicMock()
+        mock_client.get.side_effect = httpx.RequestError("Network Error")
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_class.return_value = mock_client
+
+        with pytest.raises(GeocodingError) as exc_info:
+            geocode_postal_code("48249")
+
+        assert "Netzwerkfehler" in str(exc_info.value)
+
+
+class TestRateLimiting:
+    """Tests für Rate-Limiting."""
+
+    @patch("pvforecast.geocoding.time.sleep")
+    @patch("pvforecast.geocoding.time.monotonic")
+    def test_rate_limit_enforced(self, mock_monotonic, mock_sleep):
+        """Test: Rate-Limit wird eingehalten."""
+        from pvforecast import geocoding as geocoding_module
+        from pvforecast.geocoding import _enforce_rate_limit
+
+        # Setze letzte Request-Zeit
+        geocoding_module._last_request_time = 100.0
+
+        # Simuliere: 0.5 Sekunden vergangen (zu früh für nächsten Request)
+        mock_monotonic.return_value = 100.5
+
+        _enforce_rate_limit()
+
+        # Sollte 0.5 Sekunden warten
+        mock_sleep.assert_called_once()
+        sleep_time = mock_sleep.call_args[0][0]
+        assert 0.4 < sleep_time < 0.6  # Ungefähr 0.5s
+
+    @patch("pvforecast.geocoding.time.sleep")
+    @patch("pvforecast.geocoding.time.monotonic")
+    def test_no_wait_if_enough_time_passed(self, mock_monotonic, mock_sleep):
+        """Test: Kein Warten wenn genug Zeit vergangen."""
+        import pvforecast.geocoding as geocoding_module
+
+        geocoding_module._last_request_time = 100.0
+        mock_monotonic.return_value = 102.0  # 2 Sekunden vergangen
+
+        from pvforecast.geocoding import _enforce_rate_limit
+
+        _enforce_rate_limit()
+
+        mock_sleep.assert_not_called()
+
+
+# Integration Test (optional, nur wenn NOMINATIM_INTEGRATION_TEST env var gesetzt)
+class TestIntegration:
+    """Integration-Tests mit echtem Nominatim API (optional)."""
+
+    @pytest.mark.skip(reason="Integration-Test - nur manuell ausführen")
+    def test_real_geocode_duelmen(self):
+        """Test: Echte Geocoding-Abfrage für Dülmen."""
+        result = geocode("48249 Dülmen")
+
+        assert result is not None
+        assert 51.8 < result.latitude < 51.9
+        assert 7.2 < result.longitude < 7.4
+        assert result.city is not None
+
+    @pytest.mark.skip(reason="Integration-Test - nur manuell ausführen")
+    def test_real_geocode_vienna(self):
+        """Test: Echte Geocoding-Abfrage für Wien."""
+        result = geocode("Wien", country_codes="at")
+
+        assert result is not None
+        assert result.country_code == "AT"


### PR DESCRIPTION
## Summary
Adds a new `geocoding.py` module for converting addresses/postal codes to coordinates using OpenStreetMap Nominatim API.

## Changes
- New module: `src/pvforecast/geocoding.py`
- New tests: `tests/test_geocoding.py` (25 tests)

## Features
- `geocode(query)` - Search by address or postal code
- `geocode_postal_code(postal_code)` - Specialized postal code lookup
- `GeoResult` dataclass with city/state/country extraction
- Rate-limiting (1 req/sec per Nominatim policy)
- Retry logic with exponential backoff for timeouts/429s
- Country code filtering (default: DE, AT, CH)

## API Example
```python
from pvforecast.geocoding import geocode

result = geocode("48249 Dülmen")
print(result.latitude, result.longitude)  # 51.83, 7.28
print(result.short_name())  # "Dülmen, NRW"
```

## Tests
- 25 unit tests with mocked HTTP responses
- Edge cases: timeouts, rate limits, empty results
- Integration tests (skipped by default)

## Closes
Closes #54

## Part of
#53 (Setup-Wizard)