### PR TITLE
feat: Add interactive setup wizard (pvforecast setup)

### DIFF
--- a/src/pvforecast/cli.py
+++ b/src/pvforecast/cli.py
@@ -30,6 +30,7 @@ from pvforecast.model import (
     train,
     tune,
 )
+from pvforecast.setup import SetupWizard
 from pvforecast.validation import (
     DependencyError,
     ValidationError,
@@ -666,6 +667,24 @@ def cmd_evaluate(args: argparse.Namespace, config: Config) -> int:
     return 0
 
 
+def cmd_setup(args: argparse.Namespace, config: Config) -> int:
+    """Führt den interaktiven Setup-Wizard aus."""
+    config_path = get_config_path()
+
+    if config_path.exists() and not args.force:
+        print(f"⚠️  Config existiert bereits: {config_path}")
+        print("   Verwende --force um zu überschreiben.")
+        return 1
+
+    wizard = SetupWizard()
+    try:
+        wizard.run_interactive()
+        return 0
+    except KeyboardInterrupt:
+        print("\n⚠️  Setup abgebrochen.")
+        return 130
+
+
 def cmd_config(args: argparse.Namespace, config: Config) -> int:
     """Verwaltet die Konfiguration."""
     config_path = get_config_path()
@@ -826,6 +845,14 @@ def create_parser() -> argparse.ArgumentParser:
         help="Pfad zur Config-Datei anzeigen",
     )
 
+    # setup
+    p_setup = subparsers.add_parser("setup", help="Interaktiver Einrichtungs-Assistent")
+    p_setup.add_argument(
+        "--force",
+        action="store_true",
+        help="Überschreibe existierende Konfiguration",
+    )
+
     return parser
 
 
@@ -906,6 +933,7 @@ def _run_command(args: argparse.Namespace, parser: argparse.ArgumentParser) -> i
         "status": cmd_status,
         "evaluate": cmd_evaluate,
         "config": cmd_config,
+        "setup": cmd_setup,
     }
 
     cmd_func = commands.get(args.command)

--- a/src/pvforecast/setup.py
+++ b/src/pvforecast/setup.py
@@ -1,0 +1,303 @@
+"""Interaktiver Setup-Wizard für die Ersteinrichtung.
+
+Führt den Benutzer durch die Konfiguration:
+1. Standort (PLZ/Ort → Koordinaten)
+2. Anlagenparameter (kWp, Name)
+3. Optional: XGBoost Installation
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from pvforecast.config import Config, get_config_path
+from pvforecast.geocoding import GeocodingError, geocode
+
+
+@dataclass
+class SetupResult:
+    """Ergebnis des Setup-Wizards.
+
+    Attributes:
+        config: Die erstellte Konfiguration
+        config_path: Pfad zur gespeicherten Config-Datei
+        xgboost_installed: Ob XGBoost installiert wurde
+    """
+
+    config: Config
+    config_path: Path
+    xgboost_installed: bool
+
+
+class SetupWizard:
+    """Interaktiver Setup-Wizard für pvforecast.
+
+    Führt den Benutzer durch die Ersteinrichtung und erstellt
+    eine Config-Datei mit allen notwendigen Parametern.
+    """
+
+    def __init__(self, output_func=print, input_func=input):
+        """Initialisiert den Wizard.
+
+        Args:
+            output_func: Funktion für Ausgaben (default: print)
+            input_func: Funktion für Eingaben (default: input)
+        """
+        self.output = output_func
+        self.input = input_func
+
+    def run_interactive(self) -> SetupResult:
+        """Führt den interaktiven Setup-Wizard aus.
+
+        Returns:
+            SetupResult mit Config und Status
+        """
+        self._print_header()
+
+        # 1. Standort
+        latitude, longitude, location_name = self._prompt_location()
+
+        # 2. Anlage
+        peak_kwp, system_name = self._prompt_system(location_name)
+
+        # 3. Config erstellen
+        config = Config(
+            latitude=latitude,
+            longitude=longitude,
+            peak_kwp=peak_kwp,
+            system_name=system_name,
+        )
+
+        # 4. Config speichern
+        config_path = get_config_path()
+        config.save(config_path)
+
+        # 5. Optional: XGBoost
+        xgboost_installed = self._prompt_xgboost()
+
+        self._print_success(config_path)
+
+        return SetupResult(
+            config=config,
+            config_path=config_path,
+            xgboost_installed=xgboost_installed,
+        )
+
+    def _print_header(self) -> None:
+        """Gibt den Header aus."""
+        self.output("")
+        self.output("🔆 PV-Forecast Ersteinrichtung")
+        self.output("═" * 50)
+        self.output("")
+
+    def _print_success(self, config_path: Path) -> None:
+        """Gibt die Erfolgsmeldung aus."""
+        self.output("")
+        self.output("═" * 50)
+        self.output("✅ Einrichtung abgeschlossen!")
+        self.output("═" * 50)
+        self.output("")
+        self.output(f"   Config gespeichert: {config_path}")
+        self.output("")
+        self.output("   Nächste Schritte:")
+        self.output("   1. Daten importieren:  pvforecast import <csv-dateien>")
+        self.output("   2. Modell trainieren:  pvforecast train")
+        self.output("   3. Prognose erstellen: pvforecast today")
+        self.output("")
+
+    def _prompt_location(self) -> tuple[float, float, str]:
+        """Fragt nach dem Standort.
+
+        Returns:
+            Tuple (latitude, longitude, location_name)
+        """
+        self.output("1️⃣  Standort")
+        self.output("")
+
+        while True:
+            query = self.input("   Postleitzahl oder Ort: ").strip()
+
+            if not query:
+                self.output("   ⚠️  Bitte einen Ort oder PLZ eingeben.")
+                continue
+
+            self.output("   Suche...")
+
+            try:
+                result = geocode(query)
+
+                if result is None:
+                    self.output(f"   ❌ Keine Ergebnisse für '{query}'")
+                    self.output("   Versuche eine andere Eingabe (z.B. '48249' oder 'Dülmen')")
+                    self.output("")
+                    continue
+
+                # Bestätigung
+                self.output(
+                    f"   → {result.short_name()} "
+                    f"({result.latitude:.2f}°N, {result.longitude:.2f}°E)"
+                )
+
+                confirm = self.input("   Stimmt das? [J/n]: ").strip().lower()
+                if confirm in ("", "j", "ja", "y", "yes"):
+                    self.output("   ✓")
+                    self.output("")
+                    return result.latitude, result.longitude, result.short_name()
+                else:
+                    self.output("   OK, versuche es erneut.")
+                    self.output("")
+
+            except GeocodingError as e:
+                self.output(f"   ⚠️  Geocoding-Fehler: {e}")
+                self.output("")
+
+                # Fallback: Manuelle Eingabe
+                if self._prompt_manual_location_fallback():
+                    return self._prompt_manual_location()
+
+    def _prompt_manual_location_fallback(self) -> bool:
+        """Fragt ob manuelle Eingabe gewünscht ist."""
+        response = self.input("   Koordinaten manuell eingeben? [j/N]: ").strip().lower()
+        return response in ("j", "ja", "y", "yes")
+
+    def _prompt_manual_location(self) -> tuple[float, float, str]:
+        """Manuelle Koordinaten-Eingabe."""
+        self.output("")
+        self.output("   Manuelle Eingabe:")
+
+        while True:
+            try:
+                lat_str = self.input("   Breitengrad (z.B. 51.83): ").strip()
+                latitude = float(lat_str)
+
+                if not -90 <= latitude <= 90:
+                    self.output("   ⚠️  Breitengrad muss zwischen -90 und 90 liegen.")
+                    continue
+
+                lon_str = self.input("   Längengrad (z.B. 7.28): ").strip()
+                longitude = float(lon_str)
+
+                if not -180 <= longitude <= 180:
+                    self.output("   ⚠️  Längengrad muss zwischen -180 und 180 liegen.")
+                    continue
+
+                name = self.input("   Ortsname (optional): ").strip() or "Mein Standort"
+
+                self.output("   ✓")
+                self.output("")
+                return latitude, longitude, name
+
+            except ValueError:
+                self.output("   ⚠️  Bitte eine gültige Zahl eingeben.")
+
+    def _prompt_system(self, default_name: str) -> tuple[float, str]:
+        """Fragt nach den Anlagenparametern.
+
+        Args:
+            default_name: Vorgeschlagener Anlagenname
+
+        Returns:
+            Tuple (peak_kwp, system_name)
+        """
+        self.output("2️⃣  Anlage")
+        self.output("")
+
+        # Peak-Leistung
+        while True:
+            try:
+                kwp_str = self.input("   Peakleistung in kWp: ").strip()
+                peak_kwp = float(kwp_str)
+
+                if peak_kwp <= 0:
+                    self.output("   ⚠️  Leistung muss größer als 0 sein.")
+                    continue
+
+                if peak_kwp > 1000:
+                    self.output("   ⚠️  Bist du sicher? Das sind 1 MW!")
+                    confirm = self.input("   Fortfahren? [j/N]: ").strip().lower()
+                    if confirm not in ("j", "ja", "y", "yes"):
+                        continue
+
+                break
+
+            except ValueError:
+                self.output("   ⚠️  Bitte eine gültige Zahl eingeben (z.B. 9.92).")
+
+        # Anlagenname
+        default_system_name = f"{default_name} PV" if default_name else "Meine PV-Anlage"
+        name = self.input(f"   Name (optional) [{default_system_name}]: ").strip()
+        system_name = name if name else default_system_name
+
+        self.output("   ✓")
+        self.output("")
+
+        return peak_kwp, system_name
+
+    def _prompt_xgboost(self) -> bool:
+        """Fragt ob XGBoost installiert werden soll.
+
+        Returns:
+            True wenn XGBoost erfolgreich installiert wurde
+        """
+        self.output("3️⃣  XGBoost (bessere Prognose-Genauigkeit)")
+        self.output("")
+
+        # Prüfe ob bereits installiert
+        try:
+            import xgboost  # noqa: F401
+
+            self.output("   ✓ XGBoost ist bereits installiert")
+            self.output("")
+            return True
+        except ImportError:
+            pass
+
+        response = self.input("   XGBoost installieren? [J/n]: ").strip().lower()
+
+        if response in ("n", "no", "nein"):
+            self.output(
+                "   → Übersprungen (kann später mit 'pip install xgboost' installiert werden)"
+            )
+            self.output("")
+            return False
+
+        self.output("   Installiere XGBoost...")
+
+        try:
+            subprocess.run(
+                [sys.executable, "-m", "pip", "install", "xgboost"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.output("   ✓ XGBoost installiert")
+            self.output("")
+            return True
+
+        except subprocess.CalledProcessError as e:
+            error_msg = e.stderr[:200] if e.stderr else "Unbekannter Fehler"
+            self.output(f"   ⚠️  Installation fehlgeschlagen: {error_msg}")
+            self.output("")
+
+            # macOS-spezifischer Hinweis
+            if sys.platform == "darwin":
+                self.output("   💡 Auf macOS benötigt XGBoost eventuell libomp:")
+                self.output("      brew install libomp")
+                self.output("")
+
+            self.output("   Du kannst XGBoost später manuell installieren.")
+            self.output("")
+            return False
+
+
+def run_setup() -> SetupResult:
+    """Convenience-Funktion zum Ausführen des Setup-Wizards.
+
+    Returns:
+        SetupResult mit Config und Status
+    """
+    wizard = SetupWizard()
+    return wizard.run_interactive()

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,402 @@
+"""Tests für das Setup-Modul."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from pvforecast.geocoding import GeoResult
+from pvforecast.setup import SetupResult, SetupWizard
+
+
+class TestSetupWizard:
+    """Tests für die SetupWizard Klasse."""
+
+    def test_wizard_creation(self):
+        """Test: Wizard kann erstellt werden."""
+        wizard = SetupWizard()
+        assert wizard.output == print
+        assert wizard.input == input
+
+    def test_wizard_custom_io(self):
+        """Test: Wizard mit custom I/O Funktionen."""
+        mock_output = MagicMock()
+        mock_input = MagicMock()
+        wizard = SetupWizard(output_func=mock_output, input_func=mock_input)
+        assert wizard.output == mock_output
+        assert wizard.input == mock_input
+
+
+class TestPromptLocation:
+    """Tests für _prompt_location."""
+
+    @patch("pvforecast.setup.geocode")
+    def test_successful_geocode(self, mock_geocode):
+        """Test: Erfolgreiche Geocoding-Abfrage."""
+        mock_geocode.return_value = GeoResult(
+            latitude=51.83,
+            longitude=7.28,
+            display_name="Dülmen, NRW, Deutschland",
+            city="Dülmen",
+            state="NRW",
+        )
+
+        outputs = []
+        inputs = iter(["48249", "j"])  # PLZ eingeben, bestätigen
+
+        wizard = SetupWizard(
+            output_func=lambda x: outputs.append(x),
+            input_func=lambda _: next(inputs),
+        )
+
+        lat, lon, name = wizard._prompt_location()
+
+        assert lat == 51.83
+        assert lon == 7.28
+        assert "Dülmen" in name
+
+    @patch("pvforecast.setup.geocode")
+    def test_geocode_not_confirmed_retry(self, mock_geocode):
+        """Test: Geocoding-Ergebnis nicht bestätigt, neuer Versuch."""
+        mock_geocode.side_effect = [
+            GeoResult(
+                latitude=52.0,
+                longitude=8.0,
+                display_name="Falscher Ort",
+                city="Falscher Ort",
+            ),
+            GeoResult(
+                latitude=51.83,
+                longitude=7.28,
+                display_name="Dülmen",
+                city="Dülmen",
+                state="NRW",
+            ),
+        ]
+
+        inputs = iter(["Berlin", "n", "Dülmen", "j"])  # Erst Berlin, ablehnen, dann Dülmen
+
+        wizard = SetupWizard(
+            output_func=lambda x: None,
+            input_func=lambda _: next(inputs),
+        )
+
+        lat, lon, name = wizard._prompt_location()
+
+        assert lat == 51.83
+        assert lon == 7.28
+        assert mock_geocode.call_count == 2
+
+    @patch("pvforecast.setup.geocode")
+    def test_empty_input_retry(self, mock_geocode):
+        """Test: Leere Eingabe führt zu Wiederholung."""
+        mock_geocode.return_value = GeoResult(
+            latitude=51.83,
+            longitude=7.28,
+            display_name="Dülmen",
+            city="Dülmen",
+        )
+
+        inputs = iter(["", "48249", "j"])  # Erst leer, dann PLZ
+
+        outputs = []
+        wizard = SetupWizard(
+            output_func=lambda x: outputs.append(x),
+            input_func=lambda _: next(inputs),
+        )
+
+        wizard._prompt_location()
+
+        # Sollte Warnung ausgeben
+        assert any("Bitte einen Ort" in str(o) for o in outputs)
+
+    @patch("pvforecast.setup.geocode")
+    def test_geocode_no_results_retry(self, mock_geocode):
+        """Test: Keine Ergebnisse führt zu Wiederholung."""
+        mock_geocode.side_effect = [
+            None,  # Keine Ergebnisse
+            GeoResult(
+                latitude=51.83,
+                longitude=7.28,
+                display_name="Dülmen",
+                city="Dülmen",
+            ),
+        ]
+
+        inputs = iter(["xyz123", "Dülmen", "j"])
+
+        outputs = []
+        wizard = SetupWizard(
+            output_func=lambda x: outputs.append(x),
+            input_func=lambda _: next(inputs),
+        )
+
+        wizard._prompt_location()
+
+        assert any("Keine Ergebnisse" in str(o) for o in outputs)
+
+
+class TestPromptManualLocation:
+    """Tests für _prompt_manual_location."""
+
+    def test_valid_manual_input(self):
+        """Test: Gültige manuelle Eingabe."""
+        inputs = iter(["51.83", "7.28", "Mein Ort"])
+
+        wizard = SetupWizard(
+            output_func=lambda x: None,
+            input_func=lambda _: next(inputs),
+        )
+
+        lat, lon, name = wizard._prompt_manual_location()
+
+        assert lat == 51.83
+        assert lon == 7.28
+        assert name == "Mein Ort"
+
+    def test_empty_name_uses_default(self):
+        """Test: Leerer Name verwendet Default."""
+        inputs = iter(["51.83", "7.28", ""])
+
+        wizard = SetupWizard(
+            output_func=lambda x: None,
+            input_func=lambda _: next(inputs),
+        )
+
+        lat, lon, name = wizard._prompt_manual_location()
+
+        assert name == "Mein Standort"
+
+    def test_invalid_latitude_retry(self):
+        """Test: Ungültiger Breitengrad führt zu Wiederholung."""
+        inputs = iter(["abc", "51.83", "7.28", "Test"])
+
+        outputs = []
+        wizard = SetupWizard(
+            output_func=lambda x: outputs.append(x),
+            input_func=lambda _: next(inputs),
+        )
+
+        wizard._prompt_manual_location()
+
+        assert any("gültige Zahl" in str(o) for o in outputs)
+
+    def test_latitude_out_of_range_retry(self):
+        """Test: Breitengrad außerhalb des Bereichs."""
+        inputs = iter(["95", "51.83", "7.28", "Test"])
+
+        outputs = []
+        wizard = SetupWizard(
+            output_func=lambda x: outputs.append(x),
+            input_func=lambda _: next(inputs),
+        )
+
+        wizard._prompt_manual_location()
+
+        assert any("-90 und 90" in str(o) for o in outputs)
+
+
+class TestPromptSystem:
+    """Tests für _prompt_system."""
+
+    def test_valid_system_input(self):
+        """Test: Gültige Anlagen-Eingabe."""
+        inputs = iter(["9.92", "Meine Anlage"])
+
+        wizard = SetupWizard(
+            output_func=lambda x: None,
+            input_func=lambda _: next(inputs),
+        )
+
+        kwp, name = wizard._prompt_system("Dülmen")
+
+        assert kwp == 9.92
+        assert name == "Meine Anlage"
+
+    def test_empty_name_uses_default(self):
+        """Test: Leerer Name verwendet Default mit Ortsname."""
+        inputs = iter(["9.92", ""])
+
+        wizard = SetupWizard(
+            output_func=lambda x: None,
+            input_func=lambda _: next(inputs),
+        )
+
+        kwp, name = wizard._prompt_system("Dülmen")
+
+        assert name == "Dülmen PV"
+
+    def test_invalid_kwp_retry(self):
+        """Test: Ungültige kWp führt zu Wiederholung."""
+        inputs = iter(["abc", "9.92", "Test"])
+
+        outputs = []
+        wizard = SetupWizard(
+            output_func=lambda x: outputs.append(x),
+            input_func=lambda _: next(inputs),
+        )
+
+        wizard._prompt_system("Test")
+
+        assert any("gültige Zahl" in str(o) for o in outputs)
+
+    def test_negative_kwp_retry(self):
+        """Test: Negative kWp führt zu Wiederholung."""
+        inputs = iter(["-5", "9.92", "Test"])
+
+        outputs = []
+        wizard = SetupWizard(
+            output_func=lambda x: outputs.append(x),
+            input_func=lambda _: next(inputs),
+        )
+
+        wizard._prompt_system("Test")
+
+        assert any("größer als 0" in str(o) for o in outputs)
+
+    def test_huge_kwp_confirmation(self):
+        """Test: Sehr große kWp benötigt Bestätigung."""
+        inputs = iter(["2000", "j", "Großanlage"])  # 2 MW, bestätigen
+
+        outputs = []
+        wizard = SetupWizard(
+            output_func=lambda x: outputs.append(x),
+            input_func=lambda _: next(inputs),
+        )
+
+        kwp, _ = wizard._prompt_system("Test")
+
+        assert kwp == 2000
+        assert any("1 MW" in str(o) for o in outputs)
+
+
+class TestPromptXGBoost:
+    """Tests für _prompt_xgboost."""
+
+    @patch("pvforecast.setup.subprocess.run")
+    def test_install_xgboost(self, mock_run):
+        """Test: XGBoost wird installiert."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        inputs = iter(["j"])
+
+        # Simuliere dass xgboost nicht installiert ist
+        with patch.dict("sys.modules", {"xgboost": None}):
+            # Force ImportError
+            import sys
+
+            original = sys.modules.get("xgboost")
+            if "xgboost" in sys.modules:
+                del sys.modules["xgboost"]
+
+            wizard = SetupWizard(
+                output_func=lambda x: None,
+                input_func=lambda _: next(inputs),
+            )
+
+            # Mock den Import-Check
+            with patch("builtins.__import__", side_effect=ImportError("No module")):
+                result = wizard._prompt_xgboost()
+
+            # Restore
+            if original:
+                sys.modules["xgboost"] = original
+
+        assert result is True
+        mock_run.assert_called_once()
+
+    def test_skip_xgboost(self):
+        """Test: XGBoost-Installation überspringen."""
+        inputs = iter(["n"])
+
+        # Force ImportError für xgboost check
+        with patch("builtins.__import__", side_effect=ImportError("No module")):
+            wizard = SetupWizard(
+                output_func=lambda x: None,
+                input_func=lambda _: next(inputs),
+            )
+
+            result = wizard._prompt_xgboost()
+
+        assert result is False
+
+    @patch("pvforecast.setup.subprocess.run")
+    def test_xgboost_install_failure(self, mock_run):
+        """Test: XGBoost-Installation schlägt fehl."""
+        import subprocess
+
+        mock_run.side_effect = subprocess.CalledProcessError(1, "pip", stderr="Error")
+
+        inputs = iter(["j"])
+
+        with patch("builtins.__import__", side_effect=ImportError("No module")):
+            outputs = []
+            wizard = SetupWizard(
+                output_func=lambda x: outputs.append(x),
+                input_func=lambda _: next(inputs),
+            )
+
+            result = wizard._prompt_xgboost()
+
+        assert result is False
+        assert any("fehlgeschlagen" in str(o) for o in outputs)
+
+
+class TestRunInteractive:
+    """Tests für run_interactive (Integration)."""
+
+    @patch("pvforecast.setup.geocode")
+    @patch("pvforecast.setup.get_config_path")
+    @patch.object(Path, "mkdir", return_value=None)
+    def test_full_wizard_flow(self, mock_mkdir, mock_config_path, mock_geocode, tmp_path):
+        """Test: Vollständiger Wizard-Durchlauf."""
+        config_file = tmp_path / "config.yaml"
+        mock_config_path.return_value = config_file
+
+        mock_geocode.return_value = GeoResult(
+            latitude=51.83,
+            longitude=7.28,
+            display_name="Dülmen, NRW",
+            city="Dülmen",
+            state="NRW",
+        )
+
+        # Mock XGBoost als bereits installiert
+        with patch.dict("sys.modules", {"xgboost": MagicMock()}):
+            inputs = iter([
+                "48249",  # PLZ
+                "j",  # Bestätigen
+                "9.92",  # kWp
+                "",  # Name (default)
+            ])
+
+            wizard = SetupWizard(
+                output_func=lambda x: None,
+                input_func=lambda _: next(inputs),
+            )
+
+            result = wizard.run_interactive()
+
+        assert result.config.latitude == 51.83
+        assert result.config.longitude == 7.28
+        assert result.config.peak_kwp == 9.92
+        assert "Dülmen" in result.config.system_name
+        assert result.config_path == config_file
+
+
+class TestSetupResult:
+    """Tests für SetupResult Dataclass."""
+
+    def test_creation(self, tmp_path):
+        """Test: SetupResult kann erstellt werden."""
+        from pvforecast.config import Config
+
+        config = Config(latitude=51.83, longitude=7.28, peak_kwp=9.92)
+        result = SetupResult(
+            config=config,
+            config_path=tmp_path / "config.yaml",
+            xgboost_installed=True,
+        )
+
+        assert result.config.latitude == 51.83
+        assert result.xgboost_installed is True


### PR DESCRIPTION
## Summary
Adds an interactive setup wizard for first-time configuration via `pvforecast setup`.

## Changes
- New module: `src/pvforecast/setup.py`
- New CLI command: `pvforecast setup`
- New tests: `tests/test_setup.py` (20 tests)

## Features
- **Location setup**: Enter postal code or city name → automatic geocoding to coordinates
- **System setup**: Configure peak power (kWp) and system name
- **XGBoost installation**: Optional installation with macOS libomp hint
- **Config generation**: Creates `~/.config/pvforecast/config.yaml`

## User Flow
```
🔆 PV-Forecast Ersteinrichtung
══════════════════════════════════════

1️⃣  Standort
   Postleitzahl oder Ort: 48249
   Suche...
   → Dülmen, NRW (51.83°N, 7.28°E)
   Stimmt das? [J/n]: j
   ✓

2️⃣  Anlage
   Peakleistung in kWp: 9.92
   Name (optional) [Dülmen PV]: 
   ✓

3️⃣  XGBoost (bessere Prognose-Genauigkeit)
   ✓ XGBoost ist bereits installiert

══════════════════════════════════════
✅ Einrichtung abgeschlossen!
```

## Tests
- 20 unit tests covering all wizard prompts
- Mock-based testing for geocoding and subprocess calls
- Edge cases: invalid input, retries, confirmation

## Closes
Closes #55

## Part of
#53 (Setup-Wizard)