### PR TITLE
docs: Add setup and doctor commands to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,50 +13,53 @@ Ertragsprognose für Photovoltaik-Anlagen auf Basis historischer Daten und Wette
 
 ## Installation
 
-### Quick Install (empfohlen)
-
 ```bash
 curl -sSL https://raw.githubusercontent.com/jarvis-schlappa/pv-forecast/main/install.sh | bash
 ```
 
-Das Script:
-- Prüft Abhängigkeiten (Python 3.9+, git, pip)
-- Installiert nach `~/pv-forecast`
-- Erstellt einen Wrapper für direkten `pvforecast`-Aufruf
-- Startet den interaktiven Setup-Wizard
+Nach dem Download startet automatisch der **Setup-Wizard**:
 
-### Manuelle Installation
-
-```bash
-# Repository klonen
-git clone https://github.com/jarvis-schlappa/pv-forecast.git
-cd pv-forecast
-
-# Virtual Environment
-python3 -m venv .venv
-source .venv/bin/activate
-
-# Installation
-pip install -e .
-
-# Einrichtung
-pvforecast setup
-
-# Optional: XGBoost Support (bessere Genauigkeit)
-pip install -e ".[xgb]"
 ```
+🔆 PV-Forecast Ersteinrichtung
+══════════════════════════════════════
+
+1️⃣  Standort
+   Postleitzahl oder Ort: 48249
+   → Dülmen, NRW (51.85°N, 7.26°E) ✓
+
+2️⃣  Anlage
+   Peakleistung in kWp: 9.92 ✓
+
+3️⃣  XGBoost installieren? [J/n]: j ✓
+
+✅ Einrichtung abgeschlossen!
+```
+
+Fertig! `pvforecast` ist jetzt einsatzbereit.
 
 ### Windows
 
-Das Install-Script läuft nicht nativ auf Windows. Nutze WSL:
-
 ```powershell
-# 1. WSL installieren (PowerShell als Admin)
+# 1. WSL installieren (einmalig, PowerShell als Admin)
 wsl --install
 
 # 2. Neu starten, dann in WSL-Terminal:
 curl -sSL https://raw.githubusercontent.com/jarvis-schlappa/pv-forecast/main/install.sh | bash
 ```
+
+<details>
+<summary><b>Manuelle Installation</b> (für Entwickler)</summary>
+
+```bash
+git clone https://github.com/jarvis-schlappa/pv-forecast.git
+cd pv-forecast
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[xgb]"
+pvforecast setup
+```
+
+</details>
 
 **Voraussetzungen:** Python 3.9+, git
 
@@ -79,6 +82,7 @@ pvforecast predict    # Prognose für morgen + übermorgen
 | Befehl | Beschreibung |
 |--------|--------------|
 | `pvforecast setup` | **Interaktiver Einrichtungs-Assistent** |
+| `pvforecast doctor` | **System-Diagnose und Healthcheck** |
 | `pvforecast today` | Prognose für heute |
 | `pvforecast predict` | Prognose für morgen + übermorgen |
 | `pvforecast import <csv>` | E3DC CSV importieren |
@@ -140,7 +144,7 @@ Stundenwerte
 # Dev-Dependencies
 pip install -e ".[dev]"
 
-# Tests (158 Tests)
+# Tests (222 Tests)
 pytest
 
 # Linting

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -23,6 +23,110 @@ pvforecast [GLOBALE OPTIONEN] <befehl> [BEFEHL-OPTIONEN]
 
 ## Befehle
 
+### `pvforecast setup`
+
+Interaktiver Einrichtungs-Assistent für die Erstkonfiguration.
+
+```bash
+pvforecast setup [OPTIONEN]
+```
+
+| Option | Beschreibung |
+|--------|--------------|
+| `--force` | Überschreibt existierende Konfiguration |
+
+**Ablauf:**
+
+```
+🔆 PV-Forecast Ersteinrichtung
+══════════════════════════════════════════════════
+
+1️⃣  Standort
+   Postleitzahl oder Ort: 48249
+   Suche...
+   → Dülmen, Nordrhein-Westfalen (51.85°N, 7.26°E)
+   Stimmt das? [J/n]: j
+   ✓
+
+2️⃣  Anlage
+   Peakleistung in kWp: 9.92
+   Name (optional) [Dülmen PV]: 
+   ✓
+
+3️⃣  XGBoost (bessere Prognose-Genauigkeit)
+   XGBoost installieren? [J/n]: j
+   Installiere XGBoost...
+   ✓ XGBoost installiert
+
+══════════════════════════════════════════════════
+✅ Einrichtung abgeschlossen!
+══════════════════════════════════════════════════
+
+   Config gespeichert: ~/.config/pvforecast/config.yaml
+
+   Nächste Schritte:
+   1. Daten importieren:  pvforecast import <csv-dateien>
+   2. Modell trainieren:  pvforecast train
+   3. Prognose erstellen: pvforecast today
+```
+
+**Features:**
+- Automatische Standort-Ermittlung via PLZ oder Ortsname (Geocoding)
+- Validierung aller Eingaben
+- Optional: XGBoost-Installation (mit macOS libomp-Hinweis)
+
+---
+
+### `pvforecast doctor`
+
+System-Diagnose und Healthcheck.
+
+```bash
+pvforecast doctor
+```
+
+**Keine Optionen.**
+
+**Ausgabe:**
+
+```
+🔍 PV-Forecast Systemcheck
+══════════════════════════════════════════════════
+
+ ✓ Python: 3.11.4
+ ✓ pvforecast: 0.1.0
+ ✓ Config: ~/.config/pvforecast/config.yaml
+ ✓ Standort: Dülmen PV (9.92 kWp)
+   └─ 51.85°N, 7.26°E
+ ✓ Datenbank: 62,212 PV / 62,256 Wetter
+   └─ Zeitraum: 2019-01-01 bis 2026-02-05
+ ✓ Modell: xgb (MAE: 111W)
+   └─ MAPE: 30.3%
+ ✓ XGBoost: 2.1.4
+ ✓ libomp: Installiert (Homebrew)
+ ✓ Netzwerk: Open-Meteo API erreichbar
+
+✅ Alles OK!
+```
+
+**Checks:**
+- Python-Version
+- pvforecast-Version
+- Config-Datei (Existenz & Validität)
+- Standort-Einstellungen
+- Datenbank (PV/Wetter-Datensätze, Zeitraum)
+- Modell (Typ, MAE, MAPE)
+- XGBoost-Installation
+- libomp (nur macOS)
+- Netzwerk-Konnektivität (Open-Meteo API)
+
+**Exit-Codes:**
+- `0`: Alles OK
+- `1`: Warnungen vorhanden
+- `2`: Fehler vorhanden
+
+---
+
 ### `pvforecast today`
 
 Prognose für den heutigen Tag (vergangene + kommende Stunden).


### PR DESCRIPTION
## Summary
Updates documentation for the new setup wizard and doctor commands.

## Changes

### README.md
- Add `pvforecast doctor` to command table
- Update test count: 158 → 222

### docs/CLI.md
- Add full documentation for `pvforecast setup`
  - Options (`--force`)
  - Example output with all steps
  - Feature list (Geocoding, validation, XGBoost)
- Add full documentation for `pvforecast doctor`
  - Example output
  - All checks listed
  - Exit codes explained