### PR TITLE
fix: Read stdin from /dev/tty for curl pipe compatibility

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -278,8 +278,9 @@ run_setup() {
     print_step "Starte Einrichtung..."
     echo ""
     
-    # Run setup wizard
-    "$INSTALL_DIR/.venv/bin/python" -m pvforecast setup
+    # Run setup wizard with stdin from terminal (not from pipe)
+    # This is required when running via: curl ... | bash
+    "$INSTALL_DIR/.venv/bin/python" -m pvforecast setup < /dev/tty
 }
 
 print_completion() {


### PR DESCRIPTION
## Problem
When running via `curl ... | bash`, stdin is connected to the curl pipe, not the terminal. This caused `EOFError` in the setup wizard when trying to read user input.

## Fix
Explicitly read from `/dev/tty` for the interactive setup wizard:
```bash
pvforecast setup < /dev/tty
```

## Tested
- `curl -sSL .../install.sh | bash` now works correctly
- Interactive prompts receive input from terminal