### PR TITLE
fix: Change config load message to DEBUG level

### DIFF
--- a/src/pvforecast/config.py
+++ b/src/pvforecast/config.py
@@ -172,7 +172,7 @@ def load_config(path: Path | None = None) -> Config:
         logger.debug(f"Keine Config-Datei gefunden: {path}")
         return Config()
 
-    logger.info(f"Lade Config: {path}")
+    logger.debug(f"Lade Config: {path}")
 
     try:
         with open(path) as f:


### PR DESCRIPTION
## Problem
`Lade Config: ...` appeared 4 times during `pvforecast doctor` because `load_config()` is called multiple times.

## Fix
Changed from `logger.info()` to `logger.debug()` - now only shows with `--verbose`.