### PR TITLE
fix: Add missing weather features to evaluate query

### DIFF
--- a/src/pvforecast/cli.py
+++ b/src/pvforecast/cli.py
@@ -603,7 +603,10 @@ def cmd_evaluate(args: argparse.Namespace, config: Config) -> int:
                 p.production_w,
                 w.ghi_wm2,
                 w.cloud_cover_pct,
-                w.temperature_c
+                w.temperature_c,
+                w.wind_speed_ms,
+                w.humidity_pct,
+                w.dhi_wm2
             FROM pv_readings p
             INNER JOIN weather_history w ON p.timestamp = w.timestamp
             WHERE p.timestamp >= ? AND p.timestamp <= ?


### PR DESCRIPTION
## Root Cause Analysis

**The systematic overestimation was a BUG, not a data/model issue!**

### Problem

The `evaluate` command's SQL query was missing extended weather features:
```sql
-- Missing from evaluate:
w.wind_speed_ms,
w.humidity_pct,
w.dhi_wm2
```

Since the model was trained with these 10 features, `prepare_features()` used default values (0, 50, 0) when they were missing, causing wrong predictions.

## Results

| Year | Before (Bug) | After (Fixed) |
|------|-------------|---------------|
| 2022 | +6.0% | **-3.5%** |
| 2023 | +12.0% | **-3.7%** |
| 2024 | +20.7% | **+2.0%** |
| 2025 | +15.9% | **+2.6%** |

**Model accuracy is now within ±4%** - excellent for PV forecasting! 🎉

## First Principles Investigation

The bug was found by:
1. Running direct residual analysis (showed only +3% error)
2. Comparing with `evaluate` output (+20% error)
3. Inspecting the SQL queries - found the missing columns

Fixes #77
Closes #75 (the real root cause was this bug, not degradation)