### PR TITLE
feat: peak_kwp als Feature (#83)

### DIFF
--- a/src/pvforecast/cli.py
+++ b/src/pvforecast/cli.py
@@ -183,7 +183,7 @@ def cmd_predict(args: argparse.Namespace, config: Config) -> int:
         return 1
 
     # Prognose erstellen
-    forecast = predict(model, weather_df, config.latitude, config.longitude)
+    forecast = predict(model, weather_df, config.latitude, config.longitude, config.peak_kwp)
 
     # Ausgabe formatieren
     if args.format == "json":
@@ -263,7 +263,7 @@ def cmd_today(args: argparse.Namespace, config: Config) -> int:
         return 1
 
     # Prognose erstellen
-    forecast = predict(model, weather_df, config.latitude, config.longitude)
+    forecast = predict(model, weather_df, config.latitude, config.longitude, config.peak_kwp)
 
     # Ausgabe
     now_hour = datetime.now(tz).hour
@@ -358,7 +358,8 @@ def cmd_train(args: argparse.Namespace, config: Config) -> int:
     train_start = time.perf_counter()
     try:
         model, metrics = train(
-            db, config.latitude, config.longitude, model_type, since_year=since_year
+            db, config.latitude, config.longitude, model_type,
+            since_year=since_year, peak_kwp=config.peak_kwp
         )
     except ValueError as e:
         print(f"❌ Training fehlgeschlagen: {e}", file=sys.stderr)
@@ -447,6 +448,7 @@ def cmd_tune(args: argparse.Namespace, config: Config) -> int:
                 timeout=timeout,
                 show_progress=True,
                 since_year=since_year,
+                peak_kwp=config.peak_kwp,
             )
         else:
             best_model, metrics, best_params = tune(
@@ -457,6 +459,7 @@ def cmd_tune(args: argparse.Namespace, config: Config) -> int:
                 n_iter=n_iter,
                 cv_splits=cv_splits,
                 since_year=since_year,
+                peak_kwp=config.peak_kwp,
             )
     except DependencyError as e:
         print(f"❌ {e}", file=sys.stderr)
@@ -623,7 +626,7 @@ def cmd_evaluate(args: argparse.Namespace, config: Config) -> int:
     print(f"📈 Datenpunkte: {len(df):,}")
 
     # Features erstellen und Vorhersagen machen
-    X = prepare_features(df, config.latitude, config.longitude)
+    X = prepare_features(df, config.latitude, config.longitude, config.peak_kwp)
     y_true = df["production_w"].values
     y_pred = model.predict(X)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -161,6 +161,25 @@ class TestPrepareFeatures:
         assert features.iloc[1]["effective_irradiance"] == 500
         assert features.iloc[2]["effective_irradiance"] == 0
 
+    def test_peak_kwp_feature(self):
+        """Test: peak_kwp wird als Feature hinzugefügt wenn angegeben."""
+        df = pd.DataFrame(
+            [
+                {"timestamp": 1704067200, "ghi_wm2": 500, "cloud_cover_pct": 20, "temperature_c": 15},
+                {"timestamp": 1704110400, "ghi_wm2": 800, "cloud_cover_pct": 10, "temperature_c": 20},
+            ]
+        )
+
+        # Ohne peak_kwp
+        features_no_kwp = prepare_features(df, 51.83, 7.28)
+        assert "peak_kwp" not in features_no_kwp.columns
+
+        # Mit peak_kwp
+        features_with_kwp = prepare_features(df, 51.83, 7.28, peak_kwp=9.92)
+        assert "peak_kwp" in features_with_kwp.columns
+        assert features_with_kwp.iloc[0]["peak_kwp"] == 9.92
+        assert features_with_kwp.iloc[1]["peak_kwp"] == 9.92
+
 
 class TestSaveLoadModel:
     """Tests für Modell-Speicherung."""


### PR DESCRIPTION
## Änderungen

- `prepare_features()` akzeptiert optionalen `peak_kwp` Parameter
- `train`, `tune`, `tune_optuna`, `predict` mit peak_kwp erweitert
- CLI übergibt peak_kwp aus Config
- Unit-Test hinzugefügt

## MAPE-Impact

Kein Impact (erwartet: Konstante bei gleicher Anlage).

Basis für Transfer-Learning und Target-Normalisierung.

Closes #83