### PR TITLE
perf: iterrows() durch vektorisierte Operationen ersetzen (#95)

### DIFF
--- a/src/pvforecast/model.py
+++ b/src/pvforecast/model.py
@@ -1010,17 +1010,16 @@ def predict(
         if row.sun_elevation < 0:
             predictions[i] = 0
 
-    # Hourly Forecasts erstellen
-    hourly = []
-    for _, row in weather_df.iterrows():
-        hourly.append(
-            HourlyForecast(
-                timestamp=datetime.fromtimestamp(int(row["timestamp"]), UTC_TZ),
-                production_w=predictions[len(hourly)],
-                ghi_wm2=float(row["ghi_wm2"]),
-                cloud_cover_pct=int(row["cloud_cover_pct"]),
-            )
+    # Hourly Forecasts erstellen (itertuples ist schneller als iterrows)
+    hourly = [
+        HourlyForecast(
+            timestamp=datetime.fromtimestamp(int(row.timestamp), UTC_TZ),
+            production_w=predictions[i],
+            ghi_wm2=float(row.ghi_wm2),
+            cloud_cover_pct=int(row.cloud_cover_pct),
         )
+        for i, row in enumerate(weather_df.itertuples(index=False))
+    ]
 
     # Summe berechnen (Wh → kWh)
     total_wh = sum(predictions)

--- a/src/pvforecast/weather.py
+++ b/src/pvforecast/weather.py
@@ -283,19 +283,19 @@ def save_weather_to_db(df: pd.DataFrame, db: Database) -> int:
     if "dni_wm2" not in df.columns:
         df = df.assign(dni_wm2=0.0)
 
-    # Daten für Bulk Insert vorbereiten
+    # Daten für Bulk Insert vorbereiten (itertuples ist ~100x schneller als iterrows)
     records = [
         (
-            int(row["timestamp"]),
-            float(row["ghi_wm2"]),
-            int(row["cloud_cover_pct"]),
-            float(row["temperature_c"]),
-            float(row["wind_speed_ms"]) if row["wind_speed_ms"] is not None else 0.0,
-            int(row["humidity_pct"]) if row["humidity_pct"] is not None else 50,
-            float(row["dhi_wm2"]) if row["dhi_wm2"] is not None else 0.0,
-            float(row["dni_wm2"]) if row["dni_wm2"] is not None else 0.0,
+            int(row.timestamp),
+            float(row.ghi_wm2),
+            int(row.cloud_cover_pct),
+            float(row.temperature_c),
+            float(row.wind_speed_ms) if row.wind_speed_ms is not None else 0.0,
+            int(row.humidity_pct) if row.humidity_pct is not None else 50,
+            float(row.dhi_wm2) if row.dhi_wm2 is not None else 0.0,
+            float(row.dni_wm2) if row.dni_wm2 is not None else 0.0,
         )
-        for _, row in df.iterrows()
+        for row in df.itertuples(index=False)
     ]
 
     # Bulk Insert in einer Transaktion


### PR DESCRIPTION
## Performance-Optimierungen

- **data_loader.py:** `executemany` statt Einzel-Inserts
- **weather.py:** `itertuples()` statt `iterrows()` (~100x schneller)
- **model.py:** `itertuples()` für HourlyForecast-Erstellung
- **cli.py:** `pd.to_datetime` vektorisiert statt `apply()`

## Hinweis

Die Sonnenhöhen-Berechnung (`model.py:218`) bleibt vorerst mit `apply()`, da eine echte Vektorisierung (z.B. mit pvlib.solarposition) eine komplexere Änderung erfordert.

## Workflow

- ✅ Fachexperte
- ✅ Architekt
- ✅ Entwickler
- ✅ Tester (241 Tests)
- ✅ Security

Closes #95