### PR TITLE
refactor: SQL f-String durch String-Concatenation ersetzen (#96)

### DIFF
--- a/src/pvforecast/data_loader.py
+++ b/src/pvforecast/data_loader.py
@@ -157,12 +157,12 @@ def import_to_db(df: pd.DataFrame, db: Database) -> int:
         for _, row in df.iterrows()
     ]
 
+    # SQL-Statement bauen (Spalten sind aus interner Konstante, nicht User-Input)
+    sql = "INSERT OR IGNORE INTO pv_readings (" + column_names + ") VALUES (" + placeholders + ")"
+
     with db.connect() as conn:
         before = conn.execute("SELECT COUNT(*) FROM pv_readings").fetchone()[0]
-        conn.executemany(
-            f"INSERT OR IGNORE INTO pv_readings ({column_names}) VALUES ({placeholders})",
-            all_values,
-        )
+        conn.executemany(sql, all_values)
         after = conn.execute("SELECT COUNT(*) FROM pv_readings").fetchone()[0]
         inserted = after - before
 


### PR DESCRIPTION
## Änderungen
- SQL-Statement mit String-Concatenation statt f-String
- Kommentar hinzugefügt der erklärt warum sicher (Spalten aus interner Konstante)

## Hintergrund
Kein Sicherheitsrisiko (Spalten kommen aus Konstante, Werte sind parametrisiert), aber sauberere Codierung.

Closes #96