### PR TITLE
fix(model): use degrees() instead of 3.14159 (#115)

### DIFF
--- a/src/pvforecast/model.py
+++ b/src/pvforecast/model.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import datetime
-from math import asin, cos, pi, radians, sin
+from math import asin, cos, degrees, pi, radians, sin
 from pathlib import Path
 from typing import Literal
 from zoneinfo import ZoneInfo
@@ -190,7 +190,7 @@ def calculate_sun_elevation(timestamp: int, lat: float, lon: float) -> float:
     # Clamp to [-1, 1] to avoid math domain errors
     sin_elevation = max(-1, min(1, sin_elevation))
 
-    elevation = asin(sin_elevation) * 180 / 3.14159
+    elevation = degrees(asin(sin_elevation))
 
     return elevation
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -58,6 +58,19 @@ class TestSunElevation:
 
         assert elev_equator > elev_germany
 
+    def test_precision_known_values(self):
+        """Test: Bekannte Sonnenhöhen-Werte für Präzisionsprüfung.
+
+        Sommersonnenwende (21.6.) Mittag am Äquator sollte nahe 66.5° sein
+        (90° - 23.5° Ekliptik-Neigung).
+        """
+        # 21. Juni 2024, 12:00 UTC am Äquator
+        ts = int(datetime(2024, 6, 21, 12, 0, tzinfo=UTC_TZ).timestamp())
+        elev = calculate_sun_elevation(ts, 0.0, 0.0)
+
+        # Erwarteter Wert: ~66.5° (90 - 23.44 Ekliptik)
+        assert 64.0 < elev < 69.0, f"Erwartete ~66.5°, bekam {elev:.1f}°"
+
 
 class TestPrepareFeatures:
     """Tests für Feature-Erstellung."""


### PR DESCRIPTION
## Änderungen

- Ersetzt hardcoded `3.14159` durch `math.degrees()`
- Fügt Präzisionstest für bekannte Sonnenhöhen-Werte hinzu

## Review #3 Rollen-Analyse

✅ **Entwickler:** Einfacher Fix, `degrees()` ist klarer als `* 180 / pi`
✅ **Architekt:** Konsistenz verbessert, `pi` wird weiterhin für zyklische Features genutzt
✅ **Tester:** Neuer Präzisionstest hinzugefügt
✅ **Fachexperte:** Minimaler Einfluss auf Genauigkeit (6. Nachkommastelle)

Closes #115