### PR TITLE
fix(cli): fix cmd_reset model info AttributeError (#127)

### DIFF
--- a/src/pvforecast/cli.py
+++ b/src/pvforecast/cli.py
@@ -1073,8 +1073,13 @@ def cmd_reset(args: argparse.Namespace, config: Config) -> int:
         model_info = "nicht vorhanden"
         if model_path.exists():
             try:
-                model_data = load_model(model_path)
-                model_info = f"{model_data.model_type}, MAPE {model_data.mape:.1f}%"
+                _, metrics = load_model(model_path)
+                model_type = metrics.get("model_type", "?")
+                mape = metrics.get("mape")
+                if mape is not None:
+                    model_info = f"{model_type}, MAPE {mape:.1f}%"
+                else:
+                    model_info = model_type
             except Exception:
                 model_info = "vorhanden"
         response = input(f"  [M]odell ({model_info})? [j/N]: ").strip().lower()


### PR DESCRIPTION
## Problem

`load_model()` gibt `(model, metrics)` Tuple zurück, Code behandelte es als Objekt:
```python
model_data.model_type  # AttributeError!
```

## Fix

```python
_, metrics = load_model(model_path)
model_type = metrics.get("model_type", "?")
```

## Review #3 Rollen-Analyse

✅ **Entwickler:** Klarer Bug, einfacher Fix
✅ **Architekt:** Return-Typ war nicht selbsterklärend
✅ **Tester:** Interaktiver Pfad schwer zu testen, bestehende Tests grün
✅ **Fachexperte:** UX-Bug, kein ML-Impact

Closes #127