### PR TITLE
fix(model): pass model_version to Forecast (#128)

### DIFF
--- a/src/pvforecast/cli.py
+++ b/src/pvforecast/cli.py
@@ -507,8 +507,10 @@ def cmd_predict(args: argparse.Namespace, config: Config) -> int:
         return 1
 
     # Prognose erstellen (mode="predict" für Zukunftsprognose ohne Produktions-Lags)
+    model_version = metrics.get("model_version") if metrics else None
     forecast = predict(
-        model, weather_df, config.latitude, config.longitude, config.peak_kwp, mode="predict"
+        model, weather_df, config.latitude, config.longitude, config.peak_kwp,
+        mode="predict", model_version=model_version
     )
 
     # Ausgabe formatieren
@@ -564,8 +566,10 @@ def cmd_today(args: argparse.Namespace, config: Config) -> int:
         return 1
 
     # Prognose berechnen
+    model_version = metrics.get("model_version") if metrics else None
     forecast = predict(
-        model, weather_df, config.latitude, config.longitude, config.peak_kwp, mode="predict"
+        model, weather_df, config.latitude, config.longitude, config.peak_kwp,
+        mode="predict", model_version=model_version
     )
 
     # Ausgabe

--- a/src/pvforecast/model.py
+++ b/src/pvforecast/model.py
@@ -1017,6 +1017,7 @@ def predict(
     lon: float,
     peak_kwp: float | None = None,
     mode: FeatureMode = "predict",
+    model_version: str | None = None,
 ) -> Forecast:
     """
     Erstellt Prognose basierend auf Wettervorhersage.
@@ -1038,6 +1039,7 @@ def predict(
             hourly=[],
             total_kwh=0.0,
             generated_at=datetime.now(UTC_TZ),
+            model_version=model_version or "unknown",
         )
 
     # Features erstellen (mode bestimmt ob Produktions-Lags verfügbar)
@@ -1073,6 +1075,7 @@ def predict(
         hourly=hourly,
         total_kwh=round(total_kwh, 2),
         generated_at=datetime.now(UTC_TZ),
+        model_version=model_version or "unknown",
     )
 
 


### PR DESCRIPTION
## Problem

`Forecast.model_version` war immer `rf-v1` (Default), auch bei XGBoost.

## Fix

- `model_version` Parameter zu `predict()` hinzugefügt
- CLI übergibt `metrics.get("model_version")` an predict()
- Forecast erhält korrekten Wert

## Review #3 Rollen-Analyse

✅ **Entwickler:** Einfache Erweiterung der Signatur
✅ **Architekt:** Metadata-Flow verbessert
✅ **Tester:** Bestehende Tests grün
✅ **Fachexperte:** Wichtig für Reproduzierbarkeit

Closes #128