### PR TITLE
fix(cli): use mode=today with production lags

### DIFF
--- a/src/pvforecast/db.py
+++ b/src/pvforecast/db.py
@@ -174,3 +174,25 @@ class Database:
                 FROM weather_history
             """).fetchall()
             return {(row[0], row[1]) for row in result}
+
+    def get_production_data(self, start_ts: int, end_ts: int) -> dict[int, int]:
+        """
+        Get production data for a time range as {timestamp: production_w} dict.
+
+        Args:
+            start_ts: Start Unix timestamp (inclusive)
+            end_ts: End Unix timestamp (inclusive)
+
+        Returns:
+            Dictionary mapping timestamp to production in watts
+        """
+        with self.connect() as conn:
+            result = conn.execute(
+                """
+                SELECT timestamp, production_w
+                FROM pv_readings
+                WHERE timestamp >= ? AND timestamp <= ?
+                """,
+                (start_ts, end_ts),
+            ).fetchall()
+            return {row[0]: row[1] for row in result}


### PR DESCRIPTION
Closes #129

- Add db.get_production_data() for historical production lookup
- cmd_today() merges production data when using Open-Meteo
- Uses mode=today for better accuracy with production lags
- Falls back to mode=predict when no data available