### PR TITLE
refactor: Split cli.py into cli/ package

### DIFF
--- a/src/pvforecast/cli/__init__.py
+++ b/src/pvforecast/cli/__init__.py
@@ -1,0 +1,158 @@
+"""Command-Line Interface für pvforecast.
+
+This package provides the CLI for pvforecast, split into:
+- parser.py: Argument parsing (create_parser)
+- commands.py: Command implementations (cmd_*)
+- formatters.py: Output formatting
+- helpers.py: Shared helper functions
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+from pvforecast.config import (
+    ConfigValidationError,
+    load_config,
+)
+from pvforecast.data_loader import DataImportError
+from pvforecast.model import ModelNotFoundError
+from pvforecast.sources.base import WeatherSourceError
+from pvforecast.validation import (
+    DependencyError,
+    ValidationError,
+    validate_latitude,
+    validate_longitude,
+)
+from pvforecast.weather import WeatherAPIError
+
+from .commands import (
+    cmd_config,
+    cmd_doctor,
+    cmd_evaluate,
+    cmd_fetch_forecast,
+    cmd_fetch_historical,
+    cmd_import,
+    cmd_predict,
+    cmd_reset,
+    cmd_setup,
+    cmd_status,
+    cmd_today,
+    cmd_train,
+    cmd_tune,
+    set_quiet_mode,
+)
+from .parser import create_parser
+
+__all__ = ["main", "create_parser"]
+
+
+def main() -> int:
+    """Hauptfunktion."""
+    parser = create_parser()
+    args = parser.parse_args()
+
+    # Quiet-Mode ermitteln (global oder subparser-level)
+    quiet = args.quiet or getattr(args, "sub_quiet", False)
+
+    # Logging konfigurieren
+    if quiet:
+        level = logging.WARNING
+    elif args.verbose:
+        level = logging.DEBUG
+    else:
+        level = logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(message)s" if not args.verbose else "%(levelname)s: %(message)s",
+    )
+
+    # HTTP-Logs nur bei --verbose anzeigen
+    if not args.verbose:
+        logging.getLogger("httpx").setLevel(logging.WARNING)
+        logging.getLogger("httpcore").setLevel(logging.WARNING)
+
+    # Quiet-Mode global setzen (für commands.qprint)
+    set_quiet_mode(quiet)
+
+    try:
+        return _run_command(args, parser)
+    except ValidationError as e:
+        # Benutzerfreundliche Fehlermeldung ohne Stacktrace
+        print(f"❌ Fehler: {e}", file=sys.stderr)
+        return 1
+    except ConfigValidationError as e:
+        print(f"❌ Konfigurationsfehler: {e}", file=sys.stderr)
+        return 1
+    except DependencyError as e:
+        print(f"❌ Fehlende Abhängigkeit:\n{e}", file=sys.stderr)
+        return 1
+    except DataImportError as e:
+        print(f"❌ Importfehler: {e}", file=sys.stderr)
+        return 1
+    except WeatherAPIError as e:
+        print(f"❌ Wetter-API-Fehler: {e}", file=sys.stderr)
+        return 1
+    except WeatherSourceError as e:
+        print(f"❌ Wetter-Source-Fehler: {e}", file=sys.stderr)
+        return 1
+    except ModelNotFoundError as e:
+        print(f"❌ {e}", file=sys.stderr)
+        print("   Tipp: Führe erst 'pvforecast train' aus.", file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        print("\n⚠️  Abgebrochen.", file=sys.stderr)
+        return 130
+
+
+def _run_command(args, parser) -> int:
+    """Führt den Befehl aus (innere Funktion für Fehlerbehandlung)."""
+    # Config aus Datei laden (falls vorhanden)
+    config = load_config()
+
+    # CLI-Argumente überschreiben Config-Datei
+    if args.db:
+        config.db_path = args.db
+    if args.lat:
+        try:
+            config.latitude = validate_latitude(args.lat)
+        except ValidationError as e:
+            print(f"❌ Ungültiger Breitengrad: {e}", file=sys.stderr)
+            sys.exit(1)
+    if args.lon:
+        try:
+            config.longitude = validate_longitude(args.lon)
+        except ValidationError as e:
+            print(f"❌ Ungültiger Längengrad: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    config.ensure_dirs()
+
+    # Command ausführen
+    commands = {
+        "fetch-forecast": cmd_fetch_forecast,
+        "fetch-historical": cmd_fetch_historical,
+        "predict": cmd_predict,
+        "today": cmd_today,
+        "import": cmd_import,
+        "train": cmd_train,
+        "tune": cmd_tune,
+        "status": cmd_status,
+        "evaluate": cmd_evaluate,
+        "config": cmd_config,
+        "setup": cmd_setup,
+        "doctor": cmd_doctor,
+        "reset": cmd_reset,
+    }
+
+    cmd_func = commands.get(args.command)
+    if cmd_func:
+        return cmd_func(args, config)
+    else:
+        parser.print_help()
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pvforecast/cli/__main__.py
+++ b/src/pvforecast/cli/__main__.py
@@ -1,0 +1,8 @@
+"""Entry point for `python -m pvforecast.cli`."""
+
+import sys
+
+from . import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pvforecast/cli/formatters.py
+++ b/src/pvforecast/cli/formatters.py
@@ -1,0 +1,168 @@
+"""Output formatters for pvforecast CLI."""
+
+from __future__ import annotations
+
+import json
+from zoneinfo import ZoneInfo
+
+from pvforecast.config import Config
+from pvforecast.model import EvaluationResult, Forecast
+
+# Wetter-Emojis für Ausgabe
+WEATHER_EMOJI = {
+    (0, 10): "☀️",  # klar
+    (10, 30): "🌤️",  # leicht bewölkt
+    (30, 60): "⛅",  # teilweise bewölkt
+    (60, 85): "🌥️",  # überwiegend bewölkt
+    (85, 101): "☁️",  # bedeckt
+}
+
+
+def get_weather_emoji(cloud_cover: int) -> str:
+    """Gibt Wetter-Emoji basierend auf Bewölkung zurück."""
+    for (low, high), emoji in WEATHER_EMOJI.items():
+        if low <= cloud_cover < high:
+            return emoji
+    return "☁️"
+
+
+def format_duration(seconds: float) -> str:
+    """Formatiert Sekunden als lesbare Dauer."""
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    minutes = int(seconds // 60)
+    secs = int(seconds % 60)
+    if secs == 0:
+        return f"{minutes}m"
+    return f"{minutes}m {secs}s"
+
+
+def format_forecast_table(forecast: Forecast, config: Config) -> str:
+    """Formatiert Prognose als Tabelle."""
+    tz = ZoneInfo(config.timezone)
+    lines = []
+
+    lines.append("")
+    lines.append(f"PV-Ertragsprognose für {config.system_name} ({config.peak_kwp} kWp)")
+    lines.append(f"Erstellt: {forecast.generated_at.astimezone(tz).strftime('%d.%m.%Y %H:%M')}")
+    lines.append("")
+    lines.append("═" * 60)
+    lines.append("Zusammenfassung")
+    lines.append("─" * 60)
+
+    # Tages-Summen berechnen
+    daily_kwh: dict[str, float] = {}
+    for h in forecast.hourly:
+        day_key = h.timestamp.astimezone(tz).strftime("%d.%m.")
+        daily_kwh[day_key] = daily_kwh.get(day_key, 0) + h.production_w / 1000
+
+    for day, kwh in daily_kwh.items():
+        lines.append(f"  {day}:  {kwh:>6.1f} kWh")
+
+    lines.append("  " + "─" * 20)
+    lines.append(f"  Gesamt:  {forecast.total_kwh:>6.1f} kWh")
+    lines.append("")
+    lines.append("═" * 60)
+    lines.append("Stundenwerte")
+    lines.append("─" * 60)
+    lines.append("  Zeit           Ertrag   Wetter")
+    lines.append("  " + "─" * 35)
+
+    for h in forecast.hourly:
+        local_time = h.timestamp.astimezone(tz)
+        time_str = local_time.strftime("%d.%m. %H:%M")
+        emoji = get_weather_emoji(h.cloud_cover_pct)
+
+        # Nur Stunden mit Produktion anzeigen (oder Tagesstunden)
+        if h.production_w > 0 or 6 <= local_time.hour <= 20:
+            lines.append(f"  {time_str}   {h.production_w:>5} W   {emoji}")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def format_forecast_json(forecast: Forecast) -> str:
+    """Formatiert Prognose als JSON."""
+    data = {
+        "generated_at": forecast.generated_at.isoformat(),
+        "total_kwh": forecast.total_kwh,
+        "model_version": forecast.model_version,
+        "hourly": [
+            {
+                "timestamp": h.timestamp.isoformat(),
+                "production_w": h.production_w,
+                "ghi_wm2": h.ghi_wm2,
+                "cloud_cover_pct": h.cloud_cover_pct,
+            }
+            for h in forecast.hourly
+        ],
+    }
+    return json.dumps(data, indent=2)
+
+
+def print_evaluation_result(result: EvaluationResult) -> None:
+    """Formatiert und gibt EvaluationResult aus."""
+    print(f"📊 Backtesting für {result.year}")
+    print("=" * 50)
+    print(f"📈 Datenpunkte: {result.data_points:,}")
+
+    print()
+    print("📉 Gesamtmetriken:")
+    print(f"   MAE:  {result.mae:.0f} W")
+    print(f"   RMSE: {result.rmse:.0f} W")
+    print(f"   R²:   {result.r2:.3f}")
+    print(f"   MAPE: {result.mape:.1f}% (nur Stunden > 100W)")
+
+    # Skill Score vs Persistence
+    if result.skill_score is not None and result.mae_persistence is not None:
+        print()
+        print("🎯 Skill Score (vs. Persistence):")
+        # Berechne ML MAE aus Skill Score für Anzeige
+        ml_mae = result.mae_persistence * (1 - result.skill_score / 100)
+        print(f"   ML-Modell MAE:      {ml_mae:.0f} W")
+        print(f"   Persistence MAE:    {result.mae_persistence:.0f} W")
+        if result.skill_score > 0:
+            print(f"   Skill Score:        +{result.skill_score:.1f}% (ML ist besser)")
+        else:
+            print(f"   Skill Score:        {result.skill_score:.1f}% (Persistence ist besser)")
+
+    # Performance nach Wetterbedingungen
+    print()
+    print("🌤️  Performance nach Wetter:")
+    for wb in result.weather_breakdown:
+        print(f"   {wb.label:22} MAE {wb.mae:5.0f}W, MAPE {wb.mape:5.1f}%")
+    print()
+
+    # Jahresübersicht
+    print(f"☀️  Jahresertrag {result.year}:")
+    print(f"   Tatsächlich:  {result.total_actual_kwh:,.0f} kWh")
+    print(f"   Vorhersage:   {result.total_predicted_kwh:,.0f} kWh")
+    print(f"   Abweichung:   {result.total_error_kwh:+,.0f} kWh ({result.total_error_pct:+.1f}%)")
+    print()
+
+    # Monatsübersicht
+    print("📅 Monatliche Abweichung:")
+    month_names = [
+        "Jan",
+        "Feb",
+        "Mär",
+        "Apr",
+        "Mai",
+        "Jun",
+        "Jul",
+        "Aug",
+        "Sep",
+        "Okt",
+        "Nov",
+        "Dez",
+    ]
+
+    for month in range(1, 13):
+        month_data = result.monthly[result.monthly["month"] == month]
+        if len(month_data) > 0:
+            err = month_data.iloc[0]["error_pct"]
+            bar = "█" * min(10, int(abs(err) / 2))
+            sign = "+" if err > 0 else "-" if err < 0 else " "
+            print(f"   {month_names[month - 1]}: {sign}{abs(err):5.1f}% {bar}")
+        else:
+            print(f"   {month_names[month - 1]}: keine Daten")

--- a/src/pvforecast/cli/helpers.py
+++ b/src/pvforecast/cli/helpers.py
@@ -1,0 +1,61 @@
+"""Helper functions for pvforecast CLI."""
+
+from __future__ import annotations
+
+from pvforecast.config import Config
+from pvforecast.sources.hostrada import HOSTRADASource
+from pvforecast.sources.mosmix import MOSMIXConfig, MOSMIXSource
+from pvforecast.sources.openmeteo import OpenMeteoConfig, OpenMeteoSource
+
+
+def get_forecast_source(config: Config, source_override: str | None = None):
+    """
+    Get the appropriate forecast source based on config or override.
+
+    Args:
+        config: Application config
+        source_override: Override source name (mosmix, open-meteo)
+
+    Returns:
+        ForecastSource instance
+    """
+    source = source_override or config.weather.forecast_provider
+
+    if source == "mosmix":
+        mosmix_config = MOSMIXConfig(
+            station_id=config.weather.mosmix.station_id,
+            use_mosmix_l=config.weather.mosmix.use_mosmix_l,
+            lat=config.latitude,
+            lon=config.longitude,
+        )
+        return MOSMIXSource(mosmix_config)
+    elif source == "open-meteo":
+        return OpenMeteoSource(OpenMeteoConfig(lat=config.latitude, lon=config.longitude))
+    else:
+        raise ValueError(f"Unknown forecast source: {source}")
+
+
+def get_historical_source(config: Config, source_override: str | None = None):
+    """
+    Get the appropriate historical source based on config or override.
+
+    Args:
+        config: Application config
+        source_override: Override source name (hostrada, open-meteo)
+
+    Returns:
+        HistoricalSource instance
+    """
+    source = source_override or config.weather.historical_provider
+
+    if source == "hostrada":
+        local_dir = config.weather.hostrada.local_dir
+        return HOSTRADASource(
+            latitude=config.latitude,
+            longitude=config.longitude,
+            local_dir=local_dir,
+        )
+    elif source == "open-meteo":
+        return OpenMeteoSource(OpenMeteoConfig(lat=config.latitude, lon=config.longitude))
+    else:
+        raise ValueError(f"Unknown historical source: {source}")

--- a/src/pvforecast/cli/parser.py
+++ b/src/pvforecast/cli/parser.py
@@ -1,0 +1,310 @@
+"""Argument parser for pvforecast CLI."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from pvforecast import __version__
+from pvforecast.config import DEFAULT_CONFIG
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Erstellt den Argument-Parser."""
+    parser = argparse.ArgumentParser(
+        prog="pvforecast",
+        description="PV-Ertragsprognose auf Basis historischer Daten und Wettervorhersage",
+    )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    parser.add_argument(
+        "--db",
+        type=Path,
+        help=f"Pfad zur Datenbank (default: {DEFAULT_CONFIG.db_path})",
+    )
+    parser.add_argument(
+        "--lat",
+        type=float,
+        help=f"Breitengrad (default: {DEFAULT_CONFIG.latitude})",
+    )
+    parser.add_argument(
+        "--lon",
+        type=float,
+        help=f"Längengrad (default: {DEFAULT_CONFIG.longitude})",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Ausführliche Ausgabe",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Reduzierte Ausgabe (unterdrückt Progress-Infos)",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # fetch-forecast
+    p_fetch = subparsers.add_parser("fetch-forecast", help="Holt Wettervorhersage")
+    p_fetch.add_argument(
+        "--source",
+        choices=["mosmix", "open-meteo"],
+        default=None,
+        help="Datenquelle (default: aus Config)",
+    )
+    p_fetch.add_argument(
+        "--hours",
+        type=int,
+        default=48,
+        help="Anzahl Stunden (default: 48)",
+    )
+    p_fetch.add_argument(
+        "--format",
+        choices=["table", "json", "csv"],
+        default="table",
+        help="Ausgabeformat (default: table)",
+    )
+
+    # fetch-historical
+    p_fetch_hist = subparsers.add_parser("fetch-historical", help="Holt historische Wetterdaten")
+    p_fetch_hist.add_argument(
+        "--source",
+        choices=["hostrada", "open-meteo"],
+        default=None,
+        help="Datenquelle (default: aus Config)",
+    )
+    p_fetch_hist.add_argument(
+        "--start",
+        type=str,
+        default=None,
+        help="Startdatum (YYYY-MM-DD)",
+    )
+    p_fetch_hist.add_argument(
+        "--end",
+        type=str,
+        default=None,
+        help="Enddatum (YYYY-MM-DD)",
+    )
+    p_fetch_hist.add_argument(
+        "--format",
+        choices=["table", "json", "csv"],
+        default="table",
+        help="Ausgabeformat (default: table)",
+    )
+    p_fetch_hist.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        help="Bestätigung überspringen (für Automatisierung)",
+    )
+    p_fetch_hist.add_argument(
+        "--force",
+        action="store_true",
+        help="Existierende Daten ignorieren und neu herunterladen",
+    )
+
+    # predict
+    p_predict = subparsers.add_parser("predict", help="Erstellt PV-Prognose")
+    p_predict.add_argument(
+        "--days",
+        type=int,
+        default=2,
+        help="Anzahl Tage ab morgen (default: 2 = morgen + übermorgen)",
+    )
+    p_predict.add_argument(
+        "--format",
+        choices=["table", "json", "csv"],
+        default="table",
+        help="Ausgabeformat (default: table)",
+    )
+    p_predict.add_argument(
+        "--source",
+        choices=["mosmix", "open-meteo"],
+        default=None,
+        help="Wetter-Datenquelle (default: aus Config)",
+    )
+
+    # import
+    p_import = subparsers.add_parser("import", help="Importiert E3DC CSV-Dateien")
+    p_import.add_argument(
+        "files",
+        nargs="+",
+        help="CSV-Dateien zum Importieren",
+    )
+    p_import.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        dest="sub_quiet",
+        help="Reduzierte Ausgabe",
+    )
+
+    # today
+    p_today = subparsers.add_parser("today", help="Prognose für heute")
+    p_today.add_argument(
+        "--source",
+        choices=["mosmix", "open-meteo"],
+        default=None,
+        help="Wetter-Datenquelle (default: aus Config)",
+    )
+    p_today.add_argument(
+        "--full",
+        action="store_true",
+        help="Ganzer Tag inkl. vergangener Stunden",
+    )
+    p_today.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        dest="sub_quiet",
+        help="Reduzierte Ausgabe",
+    )
+
+    # train
+    p_train = subparsers.add_parser("train", help="Trainiert das ML-Modell")
+    p_train.add_argument(
+        "--model",
+        choices=["rf", "xgb"],
+        default="rf",
+        help="Modell-Typ: rf=RandomForest (default), xgb=XGBoost",
+    )
+    p_train.add_argument(
+        "--since",
+        type=int,
+        default=None,
+        metavar="YEAR",
+        help="Nur Daten ab diesem Jahr verwenden (z.B. --since 2022)",
+    )
+    p_train.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        dest="sub_quiet",
+        help="Reduzierte Ausgabe",
+    )
+
+    # tune
+    p_tune = subparsers.add_parser("tune", help="Hyperparameter-Tuning")
+    p_tune.add_argument(
+        "--model",
+        choices=["rf", "xgb"],
+        default="xgb",
+        help="Modell-Typ: rf=RandomForest, xgb=XGBoost (default)",
+    )
+    p_tune.add_argument(
+        "--method",
+        choices=["random", "optuna"],
+        default="random",
+        help="Tuning-Methode: random=RandomizedSearchCV (default), optuna=Bayesian Optimization",
+    )
+    p_tune.add_argument(
+        "--trials",
+        type=int,
+        default=50,
+        help="Anzahl Iterationen/Trials (default: 50)",
+    )
+    p_tune.add_argument(
+        "--cv",
+        type=int,
+        default=5,
+        help="Anzahl CV-Splits (default: 5)",
+    )
+    p_tune.add_argument(
+        "--timeout",
+        type=int,
+        default=None,
+        help="Maximale Laufzeit in Sekunden (nur für Optuna)",
+    )
+    p_tune.add_argument(
+        "--since",
+        type=int,
+        default=None,
+        metavar="YEAR",
+        help="Nur Daten ab diesem Jahr verwenden (z.B. --since 2022)",
+    )
+    p_tune.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        dest="sub_quiet",
+        help="Reduzierte Ausgabe",
+    )
+
+    # status
+    subparsers.add_parser("status", help="Zeigt Status an")
+
+    # evaluate
+    p_evaluate = subparsers.add_parser("evaluate", help="Evaluiert Modell-Performance")
+    p_evaluate.add_argument(
+        "--year",
+        type=int,
+        help="Jahr für Evaluation",
+    )
+
+    # config
+    p_config = subparsers.add_parser("config", help="Konfiguration verwalten")
+    p_config.add_argument(
+        "--show",
+        action="store_true",
+        help="Aktuelle Konfiguration anzeigen",
+    )
+    p_config.add_argument(
+        "--init",
+        action="store_true",
+        help="Config-Datei mit Defaults erstellen",
+    )
+    p_config.add_argument(
+        "--path",
+        action="store_true",
+        help="Pfad zur Config-Datei anzeigen",
+    )
+
+    # setup
+    p_setup = subparsers.add_parser("setup", help="Interaktiver Einrichtungs-Assistent")
+    p_setup.add_argument(
+        "--force",
+        action="store_true",
+        help="Überschreibe existierende Konfiguration",
+    )
+
+    # doctor
+    subparsers.add_parser("doctor", help="Diagnose und Systemcheck")
+
+    # reset
+    p_reset = subparsers.add_parser("reset", help="Setzt Daten zurück (Datenbank/Modell/Config)")
+    p_reset.add_argument(
+        "--all",
+        action="store_true",
+        help="Alles löschen (Datenbank, Modell, Config)",
+    )
+    p_reset.add_argument(
+        "--database",
+        action="store_true",
+        help="Nur Datenbank löschen",
+    )
+    p_reset.add_argument(
+        "--model-file",
+        action="store_true",
+        dest="model_file",
+        help="Nur Modell löschen",
+    )
+    p_reset.add_argument(
+        "--configuration",
+        action="store_true",
+        dest="configuration",
+        help="Nur Config löschen",
+    )
+    p_reset.add_argument(
+        "--force",
+        action="store_true",
+        help="Keine Bestätigung (für Skripte)",
+    )
+    p_reset.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Nur anzeigen, nichts löschen",
+    )
+
+    return parser


### PR DESCRIPTION
## Summary
Closes #131

Refactored the monolithic `cli.py` (1654 LOC) into a well-organized `cli/` package with clear separation of concerns:

## Changes

| File | LOC | Purpose |
|------|-----|---------|
| `cli/__init__.py` | 158 | Entry point (`main`), exception handling |
| `cli/parser.py` | 310 | Argument parsing (`create_parser`) |
| `cli/commands.py` | 1019 | All `cmd_*` implementations |
| `cli/formatters.py` | 168 | Output formatting (`format_forecast_*`, emojis) |
| `cli/helpers.py` | 61 | Source helpers (`get_forecast_source`, etc.) |
| `cli/__main__.py` | 8 | Support for `python -m pvforecast.cli` |

## Benefits
- **Maintainability**: Each module has a single responsibility
- **Testability**: Easier to test individual components
- **Readability**: Find code faster by looking at the right file
- **Backwards compatible**: `pvforecast.cli:main` entry point unchanged

## Testing
- All existing tests pass ✅
- E2E tests verify CLI functionality unchanged
- Linting passes (ruff)