### PR TITLE
fix(setup): pass correct args to train() in _execute_training

### DIFF
--- a/src/pvforecast/setup.py
+++ b/src/pvforecast/setup.py
@@ -828,18 +828,18 @@ class SetupWizard:
         try:
             from pvforecast.config import _default_model_path
             from pvforecast.db import Database
-            from pvforecast.model import load_training_data, save_model, train
+            from pvforecast.model import save_model, train
 
             db = Database(config.db_path)
             model_path = _default_model_path()
 
-            # Lade Trainingsdaten
-            df = load_training_data(db, peak_kwp=config.peak_kwp)
-
             # Training durchführen
             model, metrics = train(
-                df=df,
+                db=db,
+                lat=config.latitude,
+                lon=config.longitude,
                 model_type=model_type,
+                peak_kwp=config.peak_kwp,
             )
 
             # Modell speichern


### PR DESCRIPTION
## Bug

Das Training im Setup-Wizard schlug fehl mit:
```
load_training_data() missing 2 required positional arguments: lat and lon
```

## Fix

Die `train()` Funktion erwartet `db, lat, lon` als Args und lädt die Daten selbst.
Code korrigiert um die richtige Signatur zu verwenden.