### PR TITLE
fix(setup): HOSTRADA Dateinamen-Parsing für Hex-Prefixe

### DIFF
--- a/src/pvforecast/setup.py
+++ b/src/pvforecast/setup.py
@@ -525,15 +525,23 @@ class SetupWizard:
                 self.output("   ⚠️  Keine NetCDF-Dateien gefunden")
                 return 0
 
-            # Extrahiere Jahreszahlen aus Dateinamen (Format: *_YYYYMM*.nc)
+            # Extrahiere Jahreszahlen aus Dateinamen
+            # Format: *_gn_YYYYMMDDHH-YYYYMMDDHH.nc
             import re
 
             years_months = set()
+            # HOSTRADA-Pattern: *_gn_YYYYMMDDHH-YYYYMMDDHH.nc
+            hostrada_pattern = r"_gn_(\d{4})(\d{2})\d{2}\d{2}-(\d{4})(\d{2})\d{2}\d{2}\.nc$"
             for f in nc_files:
-                # Suche nach YYYYMM Pattern
-                matches = re.findall(r"(\d{4})(\d{2})\d{2}", f.name)
-                for year, month in matches:
-                    years_months.add((int(year), int(month)))
+                match = re.search(hostrada_pattern, f.name)
+                if match:
+                    start_year, start_month = int(match.group(1)), int(match.group(2))
+                    end_year, end_month = int(match.group(3)), int(match.group(4))
+                    # Validierung
+                    if 1 <= start_month <= 12 and 1995 <= start_year <= 2100:
+                        years_months.add((start_year, start_month))
+                    if 1 <= end_month <= 12 and 1995 <= end_year <= 2100:
+                        years_months.add((end_year, end_month))
 
             if not years_months:
                 self.output("   ⚠️  Konnte Datumsbereich nicht ermitteln")


### PR DESCRIPTION
## Bug

HOSTRADA-Dateien vom DWD haben oft einen Hex-Prefix im Dateinamen:
```
c3755909661f_rsds_1hr_HOSTRADA-v1-0_BE_gn_2025020100-2025022823.nc
```

Der alte Regex `(\d{4})(\d{2})\d{2}` matchte auch den Prefix:
- `3755` als Jahr
- `90` als Monat → **'month must be in 1..12' Fehler**

## Fix

Spezifisches HOSTRADA-Pattern verwenden das nach `_gn_` sucht:
```python
hostrada_pattern = r"_gn_(\d{4})(\d{2})\d{2}\d{2}-(\d{4})(\d{2})\d{2}\d{2}\.nc$"
```

## Tests

3 neue Regression-Tests:
- `test_hex_prefix_not_parsed_as_date` - Der eigentliche Bug
- `test_various_hostrada_filenames` - Verschiedene gültige Formate
- `test_invalid_filenames_not_matched` - Ungültige werden ignoriert

## Lesson Learned

Der ursprüngliche Test für #155 prüfte nur ob die Frage gestellt wird, nicht ob das Laden funktioniert. Tests sollten auch Edge Cases bei Dateinamen abdecken.
