### PR TITLE
fix(setup): XGBoost-Verfügbarkeit vor Training prüfen

### DIFF
--- a/src/pvforecast/setup.py
+++ b/src/pvforecast/setup.py
@@ -1061,6 +1061,26 @@ class SetupWizard:
                     self._training_completed = False
                     return False
 
+            # Prüfe ob gewähltes Modell verfügbar ist
+            if model_type == "xgb":
+                try:
+                    import xgboost  # noqa: F401
+                except ImportError:
+                    self.output("   ⚠️  XGBoost ist nicht installiert!")
+                    self.output("")
+                    response = self.input("   Jetzt installieren? [J/n]: ").strip().lower()
+                    if response not in ("n", "nein", "no"):
+                        if self._install_xgboost():
+                            self.output("")
+                        else:
+                            self.output("   → Fallback auf RandomForest")
+                            self.output("")
+                            model_type = "rf"
+                    else:
+                        self.output("   → Fallback auf RandomForest")
+                        self.output("")
+                        model_type = "rf"
+
             # Training durchführen
             model, metrics = train(
                 db=db,


### PR DESCRIPTION
## Problem

Wenn XGBoost im Setup gewählt wurde aber nicht (mehr) installiert ist, schlägt das Training mit einer kryptischen Fehlermeldung fehl:

```
❌ Training fehlgeschlagen: XGBoost ist nicht installiert.
```

## Lösung

Vor dem Training wird jetzt geprüft ob XGBoost tatsächlich importiert werden kann:

```python
if model_type == "xgb":
    try:
        import xgboost
    except ImportError:
        # Installation anbieten oder Fallback auf RF
```

## Verhalten

1. **XGBoost nicht verfügbar:** "Jetzt installieren? [J/n]"
2. **Installation abgelehnt/fehlgeschlagen:** Automatischer Fallback auf RandomForest
3. **XGBoost verfügbar:** Training wie gewohnt

## Test

`TestXGBoostCheckBeforeTraining::test_xgboost_not_available_offers_install`
