### PR TITLE
feat: remove cloud_cover and related features

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -100,7 +100,7 @@ Bei PV-Forecast wird zeitbasiert gesplittet (ältere Daten zum Training, neuere 
 ### Feature Engineering
 **Merkmale ableiten** – aus Rohdaten neue, aussagekräftige Features berechnen.
 
-*Beispiel:* Aus GHI und Bewölkung wird `effective_irradiance` berechnet: GHI × (1 - Bewölkung/100)
+*Beispiel:* Aus GHI und Clear-Sky-GHI wird der `csi` (Clear-Sky-Index) berechnet.
 
 ---
 

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -69,7 +69,6 @@ pvforecast train --model xgb
 | `month_sin/cos` | Monat (zyklisch) | Timestamp |
 | `day_of_year_sin/cos` | Tag im Jahr (zyklisch) | Timestamp |
 | `ghi` | Globalstrahlung (W/m²) | Open-Meteo |
-| `cloud_cover` | Bewölkung (%) | Open-Meteo |
 | `temperature` | Temperatur (°C) | Open-Meteo |
 | `sun_elevation` | Sonnenhöhe (°) | Berechnet |
 | `wind_speed` | Windgeschwindigkeit (m/s) | Open-Meteo |
@@ -77,11 +76,14 @@ pvforecast train --model xgb
 | `dhi` | Diffusstrahlung (W/m²) | Open-Meteo |
 | `dni` | Direktstrahlung (W/m²) | Open-Meteo |
 
+> **Hinweis:** `cloud_cover` wird absichtlich NICHT als Feature verwendet (#168).
+> Forecast-APIs liefern oft inkonsistente Daten (100% Bewölkung bei hoher GHI).
+> Die Strahlungsfeatures (GHI, DNI, CSI) sind bessere Indikatoren.
+
 **Abgeleitete Features (ab v0.1.0):**
 
 | Feature | Beschreibung | Berechnung |
 |---------|--------------|------------|
-| `effective_irradiance` | Effektive Strahlung | GHI × (1 - cloud_cover/100) |
 | `csi` | Clear-Sky-Index | GHI / Clear-Sky-GHI (pvlib) |
 | `diffuse_fraction` | Diffus-Anteil | DHI / (GHI + 1) |
 | `t_module` | Modultemperatur | NOCT-basiert |
@@ -94,7 +96,6 @@ pvforecast train --model xgb
 |---------|--------------|
 | `ghi_lag_1h/3h` | GHI vor 1/3 Stunden |
 | `ghi_rolling_3h` | GHI Mittel letzte 3h |
-| `cloud_trend` | Bewölkungsänderung |
 | `production_lag_1h/2h/3h/24h` | Produktion vor X Stunden (nur Training) |
 
 ---
@@ -241,12 +242,13 @@ pvforecast evaluate --year 2024
 
 | Issue | Feature | MAPE-Verbesserung |
 |-------|---------|-------------------|
-| #80 | Zyklische Features, effective_irradiance | -0.2% |
+| #80 | Zyklische Features | -0.2% |
 | #83 | peak_kwp Normalisierung | Basis für Multi-Anlagen |
 | #82 | **Lag-Features (Wetter + Produktion)** | **-10%** |
 | #81 | CSI, DNI, Modultemperatur | -1.4% |
+| #168 | cloud_cover, effective_irradiance entfernt | **-0.8%** |
 
-**Gesamt: MAPE 41.7% → 30.1% (-11.6%)**
+**Gesamt: MAPE 41.7% → ~29% (-12.7%)**
 
 ---
 


### PR DESCRIPTION
## Änderungen

Entfernt `cloud_cover`, `cloud_trend` und `effective_irradiance` als ML-Features.

### Problem (#168)
Open-Meteo liefert inkonsistente Daten: 100% Bewölkung bei gleichzeitig hoher GHI/DNI. Das Modell lernt falsche Korrelationen.

### Lösung
- **cloud_cover** → entfernt (Strahlungsfeatures sind bessere Indikatoren)
- **cloud_trend** → entfernt (abgeleitet von cloud_cover)
- **effective_irradiance** → entfernt (redundant, schädlich bei 100% cloud)
- **Wetter-Breakdown** → von cloud_cover auf CSI umgestellt

### Ergebnisse

| Modell | MAPE | Features |
|--------|------|----------|
| Vorher (mit cloud) | 29.7% | 27 |
| **Nachher (ohne cloud)** | **28.9%** | **24** |

### Real-World Validierung (09.02.2026)

| Uhrzeit | Real | Mit cloud | Ohne cloud |
|---------|------|-----------|------------|
| 10:35 | 3876 W | 424 W ❌ | 1062 W ✓ |

Das Modell ohne cloud_cover prognostiziert bei inkonsistenten Wetterdaten realistischer.

### Checkliste
- [x] Unit Tests angepasst (43 bestanden)
- [x] Dokumentation aktualisiert
- [x] MAPE verbessert (-0.8%)

Closes #168