### PR TITLE
fix: Weather-Timestamps auf Intervallanfang normalisieren

### DIFF
--- a/src/pvforecast/data_loader.py
+++ b/src/pvforecast/data_loader.py
@@ -103,7 +103,8 @@ def load_e3dc_csv(csv_path: Path) -> pd.DataFrame:
 
     # E3DC Timestamps = Intervallende → auf Intervallanfang shiften (-1h)
     # E3DC meldet z.B. 08:00 für Produktion von 07:00-08:00.
-    # Wir normalisieren auf Intervallanfang (wie Open-Meteo, DWD).
+    # Wir normalisieren auf Intervallanfang. Open-Meteo/DWD Wetterdaten
+    # werden ebenfalls auf Intervallanfang normalisiert (siehe weather.py).
     df["timestamp"] = df["timestamp"] - 3600
 
     # Abregelung erkennen: wenn curtail_limit_w < production_w + Toleranz

--- a/src/pvforecast/sources/hostrada.py
+++ b/src/pvforecast/sources/hostrada.py
@@ -387,6 +387,10 @@ class HOSTRADASource(HistoricalSource):
         result = pd.DataFrame()
         result["timestamp"] = df.index.astype(np.int64) // 10**9  # Unix timestamp
 
+        # DWD HOSTRADA hourly data uses preceding-hour convention (interval-end).
+        # Normalize to interval-start convention (-1h), consistent with PV data.
+        result["timestamp"] = result["timestamp"] - 3600
+
         # GHI
         if "ghi" in df.columns:
             result["ghi_wm2"] = df["ghi"].values

--- a/src/pvforecast/sources/openmeteo.py
+++ b/src/pvforecast/sources/openmeteo.py
@@ -164,6 +164,10 @@ class OpenMeteoSource(ForecastSource, HistoricalSource):
         # Convert to Unix timestamp
         df["timestamp"] = df["timestamp"].astype("int64") // 10**9
 
+        # Open-Meteo radiation data is "preceding hour mean" (= interval-end).
+        # Normalize to interval-start convention (-1h), consistent with PV data.
+        df["timestamp"] = df["timestamp"] - 3600
+
         # Fill NaN with defaults
         df["ghi_wm2"] = df["ghi_wm2"].fillna(0.0)
         df["cloud_cover_pct"] = df["cloud_cover_pct"].fillna(0).astype(int)

--- a/src/pvforecast/weather.py
+++ b/src/pvforecast/weather.py
@@ -304,6 +304,11 @@ def _parse_weather_response(data: dict) -> pd.DataFrame:
     # Timestamps sind bereits UTC, zu Unix konvertieren
     df["timestamp"] = df["timestamp"].astype("int64") // 10**9
 
+    # Open-Meteo Strahlungsdaten sind "preceding hour mean" (= Intervallende).
+    # Wir normalisieren auf Intervallanfang-Konvention (-1h), konsistent mit PV-Daten.
+    # Siehe: https://open-meteo.com/en/docs ("Preceding hour mean" bei GHI/DHI/DNI)
+    df["timestamp"] = df["timestamp"] - 3600
+
     # None/NaN handling
     df["ghi_wm2"] = df["ghi_wm2"].fillna(0.0)
     df["cloud_cover_pct"] = df["cloud_cover_pct"].fillna(0).astype(int)


### PR DESCRIPTION
## Problem

Issue #177 hat die E3DC PV-Timestamps korrekt von Intervallende auf Intervallanfang verschoben (-3600s). Allerdings wurde dabei übersehen, dass **Open-Meteo Wetterdaten ebenfalls Intervallende-Konvention verwenden** ('preceding hour mean' laut Doku).

Das führte zu einem **1h Mismatch im JOIN**:
- PV: Intervallanfang (nach #177 Fix)
- Wetter: Intervallende (unverändert)
→ Produktion 09:00-10:00 wurde mit Wetter 08:00-09:00 gejoint

### Nachweis: Korrelationsanalyse

| Offset | Korrelation (Prod vs GHI) |
|--------|--------------------------|
| -1h    | 0.527                    |
| **0h (JOIN)** | **0.782** ← sollte höchste sein |
| +1h    | **0.928** ← tatsächlich höchste |

### Fix

Wetter-Timestamps (Open-Meteo, HOSTRADA) ebenfalls um -3600s shiften.

### Ergebnis nach Retrain

| Metrik | Vorher (nur PV-Fix) | Nachher (beide gefixt) |
|--------|-------------------|----------------------|
| MAPE (train) | 36.4% | **29.0%** |
| MAPE (eval 2025) | 32.5% | **25.1%** |
| R² | 0.948 | **0.969** |
| Skill Score | +66.8% | **+73.6%** |

### DB-Migration
```sql
UPDATE weather_history SET timestamp = timestamp - 3600;
```

Closes #177 (vollständig)