### PR TITLE
feat: Konfidenzintervall (P10–P90) für PV-Tagesprognose

### DIFF
--- a/docs/observation-log.md
+++ b/docs/observation-log.md
@@ -6,11 +6,6 @@ Tägliche Dokumentation: Prognose vs. Realität, Modellverhalten, Auffälligkeit
 
 ## 2026-02-10
 
-- **Ertrag:** 0.9 kWh (Zwischenstand 10:32)
-- **Außentemp:** 3.4 °C
-
-## 2026-02-10
-
 - **Ertrag:** 4.64 kWh
 - **Modell-Prognose:** 8.1 kWh
 - **open-meteo** (23:00): GHI-Summe 0 W/m²
@@ -26,4 +21,165 @@ Tägliche Dokumentation: Prognose vs. Realität, Modellverhalten, Auffälligkeit
 - **mosmix** (07:27): GHI-Summe 289 W/m²
 - **Abweichung:** -100%
 - **Außentemp:** 7.4 °C
+
+## 2026-02-12
+
+- **Ertrag:** 3.93 kWh
+- **open-meteo** (23:00): GHI-Summe 8552 W/m²
+- **mosmix** (23:00): GHI-Summe 5222 W/m²
+- **Außentemp:** 6.5 °C
+- **Hinweis:** Modell-Prognose nicht verfügbar (Eintrag nachträglich rekonstruiert)
+
+## 2026-02-13
+
+- **Ertrag:** 2.80 kWh
+- **Modell-Prognose:** 5.7 kWh
+- **open-meteo** (23:00): GHI-Summe 883 W/m²
+- **mosmix** (23:00): GHI-Summe 42 W/m²
+- **Abweichung:** -51%
+- **Außentemp:** 1.4 °C
+
+## 2026-02-14
+
+- **Ertrag:** 2.94 kWh
+- **Modell-Prognose:** 6.2 kWh
+- **open-meteo** (23:00): GHI-Summe 936 W/m²
+- **mosmix** (23:00): GHI-Summe 56 W/m²
+- **Abweichung:** -53%
+- **Außentemp:** -1.2 °C
+
+## 2026-02-15
+
+- **Ertrag:** 22.41 kWh
+- **Modell-Prognose:** 24.7 kWh
+- **open-meteo** (23:00): GHI-Summe 2418 W/m²
+- **mosmix** (23:00): GHI-Summe 89 W/m²
+- **Abweichung:** -9%
+- **Außentemp:** 0.9 °C
+
+## 2026-02-16
+
+- **Ertrag:** 5.83 kWh
+- **Modell-Prognose:** 5.6 kWh
+- **open-meteo** (23:00): GHI-Summe 875 W/m²
+- **mosmix** (23:00): GHI-Summe 58 W/m²
+- **Abweichung:** 4%
+- **Außentemp:** 3.9 °C
+
+## 2026-02-17
+
+- **Ertrag:** 8.65 kWh
+- **Modell-Prognose:** 6.4 kWh
+- **open-meteo** (23:00): GHI-Summe 1076 W/m²
+- **mosmix** (23:00): GHI-Summe 78 W/m²
+- **Abweichung:** 35%
+- **Außentemp:** 2.9 °C
+
+## 2026-02-18
+
+- **Ertrag:** 10.59 kWh
+- **Modell-Prognose:** 16.5 kWh
+- **open-meteo** (23:00): GHI-Summe 1901 W/m²
+- **mosmix** (23:00): GHI-Summe 86 W/m²
+- **Abweichung:** -36%
+- **Außentemp:** 0.5 °C
+
+## 2026-02-19
+
+- **Ertrag:** 6.24 kWh
+- **Modell-Prognose:** 4.3 kWh
+- **open-meteo** (23:00): GHI-Summe 648 W/m²
+- **mosmix** (23:00): GHI-Summe 58 W/m²
+- **Abweichung:** 45%
+- **Außentemp:** 1.4 °C
+
+## 2026-02-20
+
+- **Ertrag:** 4.14 kWh
+- **Modell-Prognose:** 7.6 kWh
+- **open-meteo** (23:00): GHI-Summe 1028 W/m²
+- **mosmix** (23:00): GHI-Summe 42 W/m²
+- **Abweichung:** -46%
+- **Außentemp:** 5.9 °C
+
+## 2026-02-21
+
+- **Ertrag:** 9.66 kWh
+- **Modell-Prognose:** 10.3 kWh
+- **open-meteo** (23:00): GHI-Summe 1358 W/m²
+- **mosmix** (23:00): GHI-Summe 61 W/m²
+- **Abweichung:** -6%
+- **Außentemp:** 9.5 °C
+
+## 2026-02-22
+
+- **Ertrag:** 2.33 kWh
+- **Modell-Prognose:** 0.7 kWh
+- **open-meteo** (23:00): GHI-Summe 80 W/m²
+- **mosmix** (23:00): GHI-Summe 25 W/m²
+- **Abweichung:** 233%
+- **Außentemp:** 10.1 °C
+
+## 2026-02-23
+
+- **Ertrag:** 6.53 kWh
+- **Modell-Prognose:** 3.8 kWh
+- **open-meteo** (23:00): GHI-Summe 766 W/m²
+- **mosmix** (23:00): GHI-Summe 89 W/m²
+- **Abweichung:** 72%
+- **Außentemp:** 9.0 °C
+
+## 2026-02-24
+
+- **Ertrag:** 6.33 kWh
+- **Modell-Prognose:** 5.2 kWh
+- **open-meteo** (23:00): GHI-Summe 900 W/m²
+- **mosmix** (23:00): GHI-Summe 61 W/m²
+- **Abweichung:** 22%
+- **Außentemp:** 10.8 °C
+
+## 2026-02-25
+
+- **Ertrag:** 17.88 kWh
+- **Modell-Prognose:** 21.9 kWh
+- **open-meteo** (23:00): GHI-Summe 2851 W/m²
+- **mosmix** (23:00): GHI-Summe 194 W/m²
+- **Abweichung:** -18%
+- **Außentemp:** 10.4 °C
+
+## 2026-02-26
+
+- **Ertrag:** 20.68 kWh
+- **Modell-Prognose:** 14.1 kWh
+- **open-meteo** (23:00): GHI-Summe 2217 W/m²
+- **mosmix** (23:00): GHI-Summe 181 W/m²
+- **Abweichung:** 47%
+- **Außentemp:** 11.3 °C
+
+## 2026-02-27
+
+- **Ertrag:** 24.82 kWh
+- **Modell-Prognose:** 26.8 kWh
+- **open-meteo** (23:00): GHI-Summe 3038 W/m²
+- **mosmix** (23:00): GHI-Summe 186 W/m²
+- **Abweichung:** -7%
+- **Außentemp:** 13.8 °C
+
+## 2026-02-28
+
+- **Ertrag:** 9.65 kWh
+- **Modell-Prognose:** 12.3 kWh
+- **open-meteo** (23:00): GHI-Summe 1387 W/m²
+- **mosmix** (23:00): GHI-Summe 119 W/m²
+- **Abweichung:** -22%
+- **Außentemp:** 7.3 °C
+
+## 2026-03-01
+
+- **Ertrag:** 21.44 kWh
+- **Modell-Prognose:** 28.3 kWh
+- **open-meteo** (23:00): GHI-Summe 3219 W/m²
+- **mosmix** (23:00): GHI-Summe 172 W/m²
+- **Abweichung:** -24%
+- **Außentemp:** 9.0 °C
 

--- a/src/pvforecast/cli/commands.py
+++ b/src/pvforecast/cli/commands.py
@@ -10,6 +10,11 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
+from pvforecast.confidence import (
+    ConfidenceResult,
+    compute_confidence,
+    get_forecast_cloud_cover,
+)
 from pvforecast.config import Config, get_config_path
 from pvforecast.data_loader import import_csv_files
 from pvforecast.db import Database
@@ -41,6 +46,7 @@ from pvforecast.weather import (
 )
 
 from .formatters import (
+    format_confidence,
     format_duration,
     format_forecast_json,
     format_forecast_table,
@@ -362,6 +368,23 @@ def cmd_predict(args: argparse.Namespace, config: Config) -> int:
         install_date=config.install_date,
     )
 
+    # Konfidenzintervalle berechnen (pro Tag)
+    confidence_map: dict[str, ConfidenceResult] = {}
+    if getattr(args, "confidence", False):
+        log_path = Path(__file__).resolve().parents[3] / "docs" / "observation-log.md"
+        # Tages-Summen berechnen
+        daily_kwh: dict[str, float] = {}
+        for h in forecast.hourly:
+            day_key = h.timestamp.astimezone(tz).strftime("%Y-%m-%d")
+            daily_kwh[day_key] = daily_kwh.get(day_key, 0) + h.production_w / 1000
+
+        for day_str, day_kwh in daily_kwh.items():
+            avg_cloud = get_forecast_cloud_cover(config.db_path, day_str, source_name)
+            if avg_cloud is not None:
+                confidence_map[day_str] = compute_confidence(
+                    day_kwh, avg_cloud, log_path, config.db_path,
+                )
+
     # Ausgabe formatieren
     if args.format == "json":
         print(format_forecast_json(forecast))
@@ -370,7 +393,7 @@ def cmd_predict(args: argparse.Namespace, config: Config) -> int:
         for h in forecast.hourly:
             print(f"{h.timestamp.isoformat()},{h.production_w},{h.ghi_wm2},{h.cloud_cover_pct}")
     else:
-        print(format_forecast_table(forecast, config))
+        print(format_forecast_table(forecast, config, confidence_map=confidence_map))
 
     return 0
 
@@ -445,10 +468,24 @@ def cmd_today(args: argparse.Namespace, config: Config) -> int:
         install_date=config.install_date,
     )
 
+    # Konfidenzintervall berechnen
+    confidence = None
+    if getattr(args, "confidence", False):
+        log_path = Path(__file__).resolve().parents[3] / "docs" / "observation-log.md"
+        today_str = today.strftime("%Y-%m-%d")
+        avg_cloud = get_forecast_cloud_cover(config.db_path, today_str, source_name)
+        if avg_cloud is not None:
+            confidence = compute_confidence(
+                forecast.total_kwh, avg_cloud, log_path, config.db_path,
+            )
+
     # Ausgabe
     if _quiet_mode:
         # Kompakte Ausgabe bei --quiet
-        print(f"{forecast.total_kwh:.1f} kWh")
+        if confidence:
+            print(f"{forecast.total_kwh:.1f} kWh ({confidence.range_str})")
+        else:
+            print(f"{forecast.total_kwh:.1f} kWh")
     else:
         print()
         print(f"PV-Prognose für heute ({today.strftime('%d.%m.%Y')})")
@@ -456,6 +493,8 @@ def cmd_today(args: argparse.Namespace, config: Config) -> int:
         print()
         print("═" * 50)
         print(f"  Erwarteter Tagesertrag:  {forecast.total_kwh:>6.1f} kWh")
+        if confidence:
+            print(format_confidence(confidence))
         print("═" * 50)
         print()
         print("  Stundenwerte")

--- a/src/pvforecast/cli/formatters.py
+++ b/src/pvforecast/cli/formatters.py
@@ -6,6 +6,7 @@ import json
 import math
 from zoneinfo import ZoneInfo
 
+from pvforecast.confidence import ConfidenceResult
 from pvforecast.config import Config
 from pvforecast.model import EvaluationResult, Forecast
 
@@ -38,7 +39,23 @@ def format_duration(seconds: float) -> str:
     return f"{minutes}m {secs}s"
 
 
-def format_forecast_table(forecast: Forecast, config: Config) -> str:
+def format_confidence(conf: ConfidenceResult) -> str:
+    """Formatiert Konfidenz-Ergebnis für Inline-Ausgabe (cmd_today)."""
+    lines = []
+    lines.append(f"  Konfidenzintervall:  {conf.range_str:>12}  (P10–P90)")
+    lines.append(
+        f"  Unsicherheit:        {conf.uncertainty_emoji} {conf.uncertainty:8}"
+        f"  ({conf.weather_emoji} {conf.weather_class}er Tag)"
+    )
+    lines.append(f"  {'':25}(basierend auf {conf.n_days} Tagen)")
+    return "\n".join(lines)
+
+
+def format_forecast_table(
+    forecast: Forecast,
+    config: Config,
+    confidence_map: dict[str, ConfidenceResult] | None = None,
+) -> str:
     """Formatiert Prognose als Tabelle."""
     tz = ZoneInfo(config.timezone)
     lines = []
@@ -51,14 +68,23 @@ def format_forecast_table(forecast: Forecast, config: Config) -> str:
     lines.append("Zusammenfassung")
     lines.append("─" * 60)
 
-    # Tages-Summen berechnen
+    # Tages-Summen berechnen (date_key und display_key getrennt)
     daily_kwh: dict[str, float] = {}
+    daily_date_key: dict[str, str] = {}  # display_key -> YYYY-MM-DD
     for h in forecast.hourly:
-        day_key = h.timestamp.astimezone(tz).strftime("%d.%m.")
-        daily_kwh[day_key] = daily_kwh.get(day_key, 0) + h.production_w / 1000
+        local = h.timestamp.astimezone(tz)
+        display_key = local.strftime("%d.%m.")
+        date_key = local.strftime("%Y-%m-%d")
+        daily_kwh[display_key] = daily_kwh.get(display_key, 0) + h.production_w / 1000
+        daily_date_key[display_key] = date_key
 
     for day, kwh in daily_kwh.items():
-        lines.append(f"  {day}:  {kwh:>6.1f} kWh")
+        date_key = daily_date_key[day]
+        conf = confidence_map.get(date_key) if confidence_map else None
+        if conf:
+            lines.append(f"  {day}:  {kwh:>6.1f} kWh  ({conf.range_str}, {conf.uncertainty_emoji})")
+        else:
+            lines.append(f"  {day}:  {kwh:>6.1f} kWh")
 
     lines.append("  " + "─" * 20)
     lines.append(f"  Gesamt:  {forecast.total_kwh:>6.1f} kWh")

--- a/src/pvforecast/cli/parser.py
+++ b/src/pvforecast/cli/parser.py
@@ -125,6 +125,11 @@ def create_parser() -> argparse.ArgumentParser:
         default=None,
         help="Wetter-Datenquelle (default: aus Config)",
     )
+    p_predict.add_argument(
+        "--confidence",
+        action="store_true",
+        help="Konfidenzintervall (P10–P90) anzeigen",
+    )
 
     # import
     p_import = subparsers.add_parser("import", help="Importiert E3DC CSV-Dateien")
@@ -153,6 +158,11 @@ def create_parser() -> argparse.ArgumentParser:
         "--full",
         action="store_true",
         help="Ganzer Tag inkl. vergangener Stunden",
+    )
+    p_today.add_argument(
+        "--confidence",
+        action="store_true",
+        help="Konfidenzintervall (P10–P90) anzeigen",
     )
     p_today.add_argument(
         "-q",

--- a/src/pvforecast/confidence.py
+++ b/src/pvforecast/confidence.py
@@ -1,0 +1,338 @@
+"""Empirische Fehlerbänder nach Wetterklasse für PV-Prognosen.
+
+Berechnet P10/P90 Konfidenzintervalle basierend auf historischen
+Tagesfehlern aus dem Observation Log, gruppiert nach Wetterklasse
+(klar/teilbewölkt/bedeckt).
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+# Wetterklassen-Grenzen (durchschnittlicher cloud_cover_pct pro Tag)
+CLEAR_THRESHOLD = 30       # < 30% = klar
+PARTLY_THRESHOLD = 70      # 30-70% = teilbewölkt, > 70% = bedeckt
+
+# Mindest-Datenpunkte pro Klasse für klassenspezifische Konfidenz
+MIN_SAMPLES_PER_CLASS = 3
+
+# Fallback wenn keine Observation-Daten verfügbar
+FALLBACK_ERROR_P10 = -0.50  # -50%
+FALLBACK_ERROR_P90 = 0.50   # +50%
+
+
+@dataclass
+class WeatherClass:
+    """Wetterklasse mit Fehlerbändern."""
+
+    name: str        # "klar", "teilbewölkt", "bedeckt"
+    emoji: str       # ☀️, ⛅, ☁️
+    error_p10: float  # 10. Perzentil des relativen Fehlers
+    error_p90: float  # 90. Perzentil des relativen Fehlers
+    n_days: int       # Anzahl Tage in dieser Klasse
+
+
+@dataclass
+class ConfidenceResult:
+    """Ergebnis der Konfidenz-Berechnung für eine Prognose."""
+
+    forecast_kwh: float
+    p10_kwh: float           # Untere Grenze (P10)
+    p90_kwh: float           # Obere Grenze (P90)
+    weather_class: str       # "klar", "teilbewölkt", "bedeckt"
+    weather_emoji: str       # ☀️, ⛅, ☁️
+    uncertainty: str         # "gering", "mittel", "hoch"
+    uncertainty_emoji: str   # 🟢, 🟡, 🔴
+    n_days: int              # Basis-Datenpunkte
+    avg_cloud_cover: float   # Durchschnittliche Bewölkung des Prognosetags
+
+    @property
+    def range_str(self) -> str:
+        """Formatiertes Intervall, z.B. '23–33 kWh'."""
+        return f"{self.p10_kwh:.0f}–{self.p90_kwh:.0f} kWh"
+
+
+def parse_observation_log(log_path: Path) -> list[dict]:
+    """Parst das Observation Log und extrahiert Prognose vs. Ist pro Tag.
+
+    Returns:
+        Liste von Dicts mit 'date', 'actual_kwh', 'forecast_kwh', 'deviation_pct'
+    """
+    if not log_path.exists():
+        return []
+
+    text = log_path.read_text(encoding="utf-8")
+    entries = []
+
+    # Split by "## YYYY-MM-DD" headers
+    sections = re.split(r"^## (\d{4}-\d{2}-\d{2})\s*$", text, flags=re.MULTILINE)
+
+    # sections[0] is preamble, then alternating date/content pairs
+    for i in range(1, len(sections), 2):
+        date_str = sections[i]
+        content = sections[i + 1] if i + 1 < len(sections) else ""
+
+        actual = _extract_float(r"\*\*Ertrag:\*\*\s*([\d.]+)\s*kWh", content)
+        forecast = _extract_float(r"\*\*Modell-Prognose:\*\*\s*([\d.]+)\s*kWh", content)
+
+        if actual is not None and forecast is not None and forecast > 0:
+            rel_error = (actual - forecast) / forecast
+            entries.append({
+                "date": date_str,
+                "actual_kwh": actual,
+                "forecast_kwh": forecast,
+                "rel_error": rel_error,
+            })
+
+    return entries
+
+
+def get_daily_cloud_cover(db_path: Path, dates: list[str]) -> dict[str, float]:
+    """Holt durchschnittlichen cloud_cover_pct pro Tag aus forecast_history.
+
+    Verwendet den letzten verfügbaren Forecast (höchstes issued_at) pro Tag
+    und mittelt die Tagesstunden (06:00–20:00 Lokalzeit).
+
+    Args:
+        db_path: Pfad zur SQLite-Datenbank
+        dates: Liste von Datumsstrings 'YYYY-MM-DD'
+
+    Returns:
+        Dict {date_str: avg_cloud_cover_pct}
+    """
+    if not db_path.exists() or not dates:
+        return {}
+
+    conn = sqlite3.connect(str(db_path))
+    result = {}
+
+    for date_str in dates:
+        # Letzte verfügbare Prognose für diesen Tag verwenden
+        # Mittele nur Tagesstunden (6-20 Uhr) für bessere Repräsentativität
+        row = conn.execute("""
+            SELECT AVG(cloud_cover_pct)
+            FROM forecast_history
+            WHERE date(target_time, 'unixepoch', 'localtime') = ?
+              AND CAST(strftime('%H', target_time, 'unixepoch', 'localtime')
+                  AS INTEGER) BETWEEN 6 AND 20
+              AND source = 'open-meteo'
+              AND issued_at = (
+                  SELECT MAX(issued_at) FROM forecast_history
+                  WHERE date(target_time, 'unixepoch', 'localtime') = ?
+                    AND source = 'open-meteo'
+              )
+        """, (date_str, date_str)).fetchone()
+
+        if row and row[0] is not None:
+            result[date_str] = float(row[0])
+
+    conn.close()
+    return result
+
+
+def classify_weather(avg_cloud: float) -> tuple[str, str]:
+    """Klassifiziert Bewölkung in Wetterklasse.
+
+    Returns:
+        (name, emoji) Tuple
+    """
+    if avg_cloud < CLEAR_THRESHOLD:
+        return "klar", "☀️"
+    elif avg_cloud < PARTLY_THRESHOLD:
+        return "teilbewölkt", "⛅"
+    else:
+        return "bedeckt", "☁️"
+
+
+def compute_error_bands(
+    log_path: Path,
+    db_path: Path,
+) -> dict[str, WeatherClass]:
+    """Berechnet empirische Fehlerbänder pro Wetterklasse.
+
+    Returns:
+        Dict {weather_class_name: WeatherClass}
+    """
+    entries = parse_observation_log(log_path)
+    if not entries:
+        return _fallback_bands()
+
+    dates = [e["date"] for e in entries]
+    cloud_cover = get_daily_cloud_cover(db_path, dates)
+
+    # Fehler nach Wetterklasse gruppieren
+    class_errors: dict[str, list[float]] = {
+        "klar": [],
+        "teilbewölkt": [],
+        "bedeckt": [],
+    }
+
+    for entry in entries:
+        avg_cloud = cloud_cover.get(entry["date"])
+        if avg_cloud is None:
+            continue
+        cls_name, _ = classify_weather(avg_cloud)
+        class_errors[cls_name].append(entry["rel_error"])
+
+    # Globale Fehler als Fallback
+    all_errors = [e["rel_error"] for e in entries if e["date"] in cloud_cover]
+
+    bands = {}
+    for cls_name, emoji in [("klar", "☀️"), ("teilbewölkt", "⛅"), ("bedeckt", "☁️")]:
+        errors = class_errors[cls_name]
+        if len(errors) >= MIN_SAMPLES_PER_CLASS:
+            arr = np.array(errors)
+            bands[cls_name] = WeatherClass(
+                name=cls_name,
+                emoji=emoji,
+                error_p10=float(np.percentile(arr, 10)),
+                error_p90=float(np.percentile(arr, 90)),
+                n_days=len(errors),
+            )
+        elif all_errors:
+            # Fallback: globale Verteilung
+            arr = np.array(all_errors)
+            bands[cls_name] = WeatherClass(
+                name=cls_name,
+                emoji=emoji,
+                error_p10=float(np.percentile(arr, 10)),
+                error_p90=float(np.percentile(arr, 90)),
+                n_days=len(all_errors),
+            )
+        else:
+            bands[cls_name] = WeatherClass(
+                name=cls_name,
+                emoji=emoji,
+                error_p10=FALLBACK_ERROR_P10,
+                error_p90=FALLBACK_ERROR_P90,
+                n_days=0,
+            )
+
+    return bands
+
+
+def compute_confidence(
+    forecast_kwh: float,
+    avg_cloud_cover: float,
+    log_path: Path,
+    db_path: Path,
+) -> ConfidenceResult:
+    """Berechnet Konfidenzintervall für eine Tagesprognose.
+
+    Args:
+        forecast_kwh: Modell-Prognose in kWh
+        avg_cloud_cover: Durchschnittlicher cloud_cover_pct für den Tag (6-20 Uhr)
+        log_path: Pfad zum Observation Log
+        db_path: Pfad zur SQLite-Datenbank
+
+    Returns:
+        ConfidenceResult mit P10/P90 und Metadaten
+    """
+    bands = compute_error_bands(log_path, db_path)
+    cls_name, cls_emoji = classify_weather(avg_cloud_cover)
+    band = bands[cls_name]
+
+    # P10/P90 berechnen
+    p10 = max(0, forecast_kwh * (1 + band.error_p10))
+    p90 = max(0, forecast_kwh * (1 + band.error_p90))
+
+    # Sicherstellen dass p10 <= p90
+    if p10 > p90:
+        p10, p90 = p90, p10
+
+    # Unsicherheit bewerten (Breite des Intervalls relativ zur Prognose)
+    if forecast_kwh > 0:
+        spread = (p90 - p10) / forecast_kwh
+    else:
+        spread = 0
+
+    if spread < 0.3:
+        uncertainty = "gering"
+        uncertainty_emoji = "🟢"
+    elif spread < 0.6:
+        uncertainty = "mittel"
+        uncertainty_emoji = "🟡"
+    else:
+        uncertainty = "hoch"
+        uncertainty_emoji = "🔴"
+
+    return ConfidenceResult(
+        forecast_kwh=forecast_kwh,
+        p10_kwh=round(p10, 1),
+        p90_kwh=round(p90, 1),
+        weather_class=cls_name,
+        weather_emoji=cls_emoji,
+        uncertainty=uncertainty,
+        uncertainty_emoji=uncertainty_emoji,
+        n_days=band.n_days,
+        avg_cloud_cover=avg_cloud_cover,
+    )
+
+
+def get_forecast_cloud_cover(
+    db_path: Path,
+    target_date: str,
+    source: str = "open-meteo",
+) -> float | None:
+    """Holt den durchschnittlichen cloud_cover für einen Prognosetag (6-20 Uhr).
+
+    Args:
+        db_path: Pfad zur SQLite-Datenbank
+        target_date: Datum als 'YYYY-MM-DD'
+        source: Wetter-Quelle
+
+    Returns:
+        Durchschnittlicher cloud_cover_pct oder None
+    """
+    if not db_path.exists():
+        return None
+
+    conn = sqlite3.connect(str(db_path))
+    row = conn.execute("""
+        SELECT AVG(cloud_cover_pct)
+        FROM forecast_history
+        WHERE date(target_time, 'unixepoch', 'localtime') = ?
+          AND CAST(strftime('%H', target_time, 'unixepoch', 'localtime')
+              AS INTEGER) BETWEEN 6 AND 20
+          AND source = ?
+          AND issued_at = (
+              SELECT MAX(issued_at) FROM forecast_history
+              WHERE date(target_time, 'unixepoch', 'localtime') = ?
+                AND source = ?
+          )
+    """, (target_date, source, target_date, source)).fetchone()
+    conn.close()
+
+    if row and row[0] is not None:
+        return float(row[0])
+    return None
+
+
+def _fallback_bands() -> dict[str, WeatherClass]:
+    """Gibt konservative Fallback-Fehlerbänder zurück."""
+    return {
+        name: WeatherClass(
+            name=name,
+            emoji=emoji,
+            error_p10=FALLBACK_ERROR_P10,
+            error_p90=FALLBACK_ERROR_P90,
+            n_days=0,
+        )
+        for name, emoji in [("klar", "☀️"), ("teilbewölkt", "⛅"), ("bedeckt", "☁️")]
+    }
+
+
+def _extract_float(pattern: str, text: str) -> float | None:
+    """Extrahiert eine Float-Zahl aus Text per Regex."""
+    match = re.search(pattern, text)
+    if match:
+        try:
+            return float(match.group(1))
+        except ValueError:
+            return None
+    return None

--- a/tests/test_confidence.py
+++ b/tests/test_confidence.py
@@ -1,0 +1,160 @@
+"""Tests für das Konfidenz-Modul."""
+
+from pathlib import Path
+
+import pytest
+
+from pvforecast.confidence import (
+    ConfidenceResult,
+    classify_weather,
+    compute_error_bands,
+    parse_observation_log,
+)
+
+
+@pytest.fixture
+def sample_log(tmp_path: Path) -> Path:
+    """Erstellt ein minimales Observation Log für Tests."""
+    log = tmp_path / "observation-log.md"
+    log.write_text(
+        """# PV-Forecast Observation Log
+
+---
+
+## 2026-02-15
+
+- **Ertrag:** 22.41 kWh
+- **Modell-Prognose:** 24.7 kWh
+- **Abweichung:** -9%
+
+## 2026-02-16
+
+- **Ertrag:** 5.83 kWh
+- **Modell-Prognose:** 5.6 kWh
+- **Abweichung:** 4%
+
+## 2026-02-17
+
+- **Ertrag:** 8.65 kWh
+- **Modell-Prognose:** 6.4 kWh
+- **Abweichung:** 35%
+
+## 2026-02-22
+
+- **Ertrag:** 2.33 kWh
+- **Modell-Prognose:** 0.7 kWh
+- **Abweichung:** 233%
+""",
+        encoding="utf-8",
+    )
+    return log
+
+
+class TestParseObservationLog:
+    def test_parse_entries(self, sample_log: Path):
+        entries = parse_observation_log(sample_log)
+        assert len(entries) == 4
+        assert entries[0]["date"] == "2026-02-15"
+        assert entries[0]["actual_kwh"] == 22.41
+        assert entries[0]["forecast_kwh"] == 24.7
+
+    def test_relative_error(self, sample_log: Path):
+        entries = parse_observation_log(sample_log)
+        # (22.41 - 24.7) / 24.7 ≈ -0.0927
+        assert abs(entries[0]["rel_error"] - (-0.0927)) < 0.01
+
+    def test_empty_file(self, tmp_path: Path):
+        log = tmp_path / "empty.md"
+        log.write_text("# Empty Log\n")
+        entries = parse_observation_log(log)
+        assert entries == []
+
+    def test_nonexistent_file(self, tmp_path: Path):
+        log = tmp_path / "nonexistent.md"
+        entries = parse_observation_log(log)
+        assert entries == []
+
+    def test_skips_entries_without_forecast(self, tmp_path: Path):
+        """Einträge ohne Modell-Prognose werden übersprungen."""
+        log = tmp_path / "partial.md"
+        log.write_text(
+            """# Log
+
+## 2026-02-12
+
+- **Ertrag:** 3.93 kWh
+- **Hinweis:** Modell-Prognose nicht verfügbar
+""",
+            encoding="utf-8",
+        )
+        entries = parse_observation_log(log)
+        assert entries == []
+
+
+class TestClassifyWeather:
+    def test_clear(self):
+        name, emoji = classify_weather(10.0)
+        assert name == "klar"
+        assert emoji == "☀️"
+
+    def test_partly_cloudy(self):
+        name, emoji = classify_weather(50.0)
+        assert name == "teilbewölkt"
+        assert emoji == "⛅"
+
+    def test_overcast(self):
+        name, emoji = classify_weather(85.0)
+        assert name == "bedeckt"
+        assert emoji == "☁️"
+
+    def test_boundary_clear_partly(self):
+        name, _ = classify_weather(30.0)
+        assert name == "teilbewölkt"  # 30% ist Grenze → teilbewölkt
+
+    def test_boundary_partly_overcast(self):
+        name, _ = classify_weather(70.0)
+        assert name == "bedeckt"  # 70% ist Grenze → bedeckt
+
+
+class TestComputeErrorBands:
+    def test_fallback_without_log(self, tmp_path: Path):
+        """Ohne Observation Log → Fallback-Bänder."""
+        log = tmp_path / "nonexistent.md"
+        db = tmp_path / "nonexistent.db"
+        bands = compute_error_bands(log, db)
+        assert "klar" in bands
+        assert "teilbewölkt" in bands
+        assert "bedeckt" in bands
+        # Fallback: N=0
+        assert bands["klar"].n_days == 0
+
+
+class TestConfidenceResult:
+    def test_range_str(self):
+        conf = ConfidenceResult(
+            forecast_kwh=28.2,
+            p10_kwh=23.0,
+            p90_kwh=33.0,
+            weather_class="klar",
+            weather_emoji="☀️",
+            uncertainty="gering",
+            uncertainty_emoji="🟢",
+            n_days=10,
+            avg_cloud_cover=15.0,
+        )
+        assert conf.range_str == "23–33 kWh"
+
+    def test_p10_less_than_p90(self):
+        """P10 sollte immer <= P90 sein."""
+        conf = ConfidenceResult(
+            forecast_kwh=10.0,
+            p10_kwh=8.0,
+            p90_kwh=12.0,
+            weather_class="bedeckt",
+            weather_emoji="☁️",
+            uncertainty="mittel",
+            uncertainty_emoji="🟡",
+            n_days=5,
+            avg_cloud_cover=85.0,
+        )
+        assert conf.p10_kwh <= conf.p90_kwh


### PR DESCRIPTION
## Closes #193

### Was?
Empirische Fehlerbänder nach Wetterklasse für PV-Tagesprognosen. Zeigt ein Konfidenzintervall (P10–P90) basierend auf historischen Tagesfehlern aus dem Observation Log, gruppiert nach Wetterklasse.

### Wie?
1. **Observation Log parsen** → relativer Fehler pro Tag: `(ist - prognose) / prognose`
2. **Cloud Cover aus forecast_history** → durchschnittlicher cloud_cover_pct (6–20 Uhr)
3. **Drei Wetterklassen:** klar (<30%), teilbewölkt (30–70%), bedeckt (>70%)
4. **P10/P90** pro Klasse, Fallback auf globale Verteilung bei weniger als 3 Datenpunkten
5. **`--confidence` Flag** für `pvforecast today` und `pvforecast predict`

### Ausgabe-Beispiel
```
PV-Prognose für heute (02.03.2026)
══════════════════════════════════════════════════
  Erwarteter Tagesertrag:    28.2 kWh
  Konfidenzintervall:     14–43 kWh  (P10–P90)
  Unsicherheit:        🔴 hoch      (☀️ klarer Tag)
                           (basierend auf 19 Tagen)
══════════════════════════════════════════════════
```

### Housekeeping
- Doppelten Eintrag 2026-02-10 im Observation Log bereinigt (Zwischenstand-Eintrag entfernt)
- Fehlenden Eintrag 2026-02-12 rekonstruiert (3.93 kWh actual, ohne Modell-Prognose)

### Dateien
- `src/pvforecast/confidence.py` – Kernlogik (neu)
- `tests/test_confidence.py` – 13 Tests (neu)
- `cli/parser.py` – --confidence Flag
- `cli/commands.py` – Integration in cmd_today/cmd_predict
- `cli/formatters.py` – format_confidence + erweitertes format_forecast_table
- `docs/observation-log.md` – Housekeeping

## 5-Rollen-Review

### Fachexperte
- [x] Domäne verstanden, Abhängigkeiten geprüft
- Ergebnis: Observation Log parsen, forecast_history Cloud Cover joinen, 3 Wetterklassen, Fallback bei N<3

### Entwickler
- [x] Minimal implementiert, bestehenden Stil gematcht
- Ergebnis: 1 neues Modul, 3 geänderte CLI-Dateien. Opt-in via --confidence

### Architekt
- [x] Einfachste Lösung, keine ungewollten Änderungen
- Ergebnis: Kein DB-Schema-Change, kein Caching, rein additiv

### Tester
- [x] 357 Tests grün (344 bestehend + 13 neu), E2E via CLI verifiziert

### Security
- [x] Read-only DB mit Parameter-Binding, keine neuen Netzwerk-Verbindungen